### PR TITLE
Remove usage of regex

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(Rapidjson REQUIRED)
 find_package(RdKafka REQUIRED)
 find_package(FlatBuffers REQUIRED)
 find_package(StreamingDataTypes COMPONENTS ce9a4745431e54bc45b0c927857a866fa77b84ec)
-find_package(PCREX REQUIRED)
 find_package(CURL)
 find_package(GraylogLogger)
 find_package(StaticData COMPONENTS "schema-config-global.json")
@@ -33,7 +32,6 @@ ${RDKAFKA_INCLUDE_DIR}
 ${FLATBUFFERS_INCLUDE_DIR}
 ${RAPIDJSON_INCLUDE_DIR}
 ${CURL_INCLUDE_DIRS}
-${PCREX_INCLUDE_DIRS}
 ${EPICSV4_INCLUDE_DIRS}
 ${PROJECT_SOURCE_DIR}/src
 ${PROJECT_BINARY_DIR}/src
@@ -46,18 +44,13 @@ ${path_library_epics_pvAccess}
 ${path_library_epics_NT}
 ${RDKAFKA_LIBRARIES}
 ${CURL_LIBRARIES}
-${PCREX_LIBRARIES}
 )
 
-if(UNIX)
-    list(APPEND libraries_common pthread)
-endif(UNIX)
-
-set(compile_defs_common ${PCREX_COMPILER_DEFINITIONS})
-
-if (PCREX_MAJOR EQUAL 2)
-	list(APPEND compile_defs_common "use_pcre2=1")
+if (UNIX)
+  list(APPEND libraries_common pthread)
 endif()
+
+set(compile_defs_common "")
 
 if (CURL_FOUND)
 	list(APPEND compile_defs_common "HAVE_CURL=1")

--- a/src/Main.cxx
+++ b/src/Main.cxx
@@ -376,7 +376,6 @@ int Main::mapping_add(rapidjson::Value &mapping) {
       if (cname.size() == 0) {
         cname = fmt::format("converter_{}", converter_ix++);
       }
-      uri::URI topic_uri(topic);
       auto r1 = main_opt.schema_registry.items().find(schema);
       if (r1 == main_opt.schema_registry.items().end()) {
         LOG(3, "can not handle (yet?) schema id {}", schema);
@@ -385,8 +384,13 @@ int Main::mapping_add(rapidjson::Value &mapping) {
       if (main_opt.brokers.size() > 0) {
         uri = main_opt.brokers.at(0);
       }
-      topic_uri.default_host(uri.host);
-      topic_uri.default_port(uri.port);
+      uri::URI topic_uri;
+      if (not uri.host.empty()) {
+        topic_uri.host = uri.host;
+      }
+      if (uri.port != 0) {
+        topic_uri.port = uri.port;
+      }
       Converter::sptr conv;
       if (cname.size() > 0) {
         auto lock = get_lock_converters();

--- a/src/MainOpt.cxx
+++ b/src/MainOpt.cxx
@@ -41,7 +41,7 @@ void MainOpt::set_broker(string broker) {
   for (auto &x : a) {
     uri::URI u1;
     u1.require_host_slashes = false;
-    u1.init(x);
+    u1.parse(x);
     brokers.push_back(u1);
   }
 }
@@ -186,8 +186,8 @@ int MainOpt::parse_json_file(string config_file) {
     auto &v = d.FindMember("status-uri")->value;
     if (v.IsString()) {
       uri::URI u1;
-      u1.init(v.GetString());
-      u1.default_port(9092);
+      u1.port = 9092;
+      u1.parse(v.GetString());
       status_uri = u1;
     }
   }
@@ -259,8 +259,8 @@ std::pair<int, std::unique_ptr<MainOpt>> parse_opt(int argc, char **argv) {
       }
       if (std::string("broker-config") == lname) {
         uri::URI u1;
-        u1.init(optarg);
-        u1.default_port(9092);
+        u1.port = 9092;
+        u1.parse(optarg);
         opt.broker_config = u1;
       }
       if (std::string("broker") == lname) {
@@ -286,8 +286,8 @@ std::pair<int, std::unique_ptr<MainOpt>> parse_opt(int argc, char **argv) {
       }
       if (std::string("status-uri") == lname) {
         uri::URI u1;
-        u1.init(optarg);
-        u1.default_port(9092);
+        u1.port = 9092;
+        u1.parse(optarg);
         opt.status_uri = u1;
       }
     }

--- a/src/MainOpt.cxx
+++ b/src/MainOpt.cxx
@@ -50,8 +50,9 @@ std::string MainOpt::brokers_as_comma_list() const {
   std::string s1;
   int i1 = 0;
   for (auto &x : brokers) {
-    if (i1)
+    if (i1) {
       s1 += ",";
+    }
     s1 += x.host_port;
     ++i1;
   }

--- a/src/tests/remote.cxx
+++ b/src/tests/remote.cxx
@@ -321,8 +321,8 @@ TEST_F(Remote_T, simple_f142_via_config_message) {
                               &channel](rapidjson::Value &s) {
               auto topic = get_string(&s, "topic");
               uri::URI topic_uri(topic);
-              topic_uri.default_host(Tests::main_opt->brokers.at(0).host);
-              topic_uri.default_port(Tests::main_opt->brokers.at(0).port);
+              topic_uri.host = Tests::main_opt->brokers.at(0).host;
+              topic_uri.port = Tests::main_opt->brokers.at(0).port;
               LOG(7, "broker: {}  topic: {}  channel: {}", topic_uri.host_port,
                   topic_uri.topic, channel);
               bopt.address = topic_uri.host_port;
@@ -393,8 +393,8 @@ TEST_F(Remote_T, named_converter) {
                               &channel](rapidjson::Value &s) {
               auto topic = get_string(&s, "topic");
               uri::URI topic_uri(topic);
-              topic_uri.default_host(Tests::main_opt->brokers.at(0).host);
-              topic_uri.default_port(Tests::main_opt->brokers.at(0).port);
+              topic_uri.host = Tests::main_opt->brokers.at(0).host;
+              topic_uri.port = Tests::main_opt->brokers.at(0).port;
               LOG(7, "broker: {}  topic: {}  channel: {}", topic_uri.host_port,
                   topic_uri.topic, channel);
               bopt.address = topic_uri.host_port;
@@ -463,8 +463,8 @@ TEST_F(Remote_T, different_brokers) {
                               &channel](rapidjson::Value &s) {
               auto topic = get_string(&s, "topic");
               uri::URI topic_uri(topic);
-              topic_uri.default_host(Tests::main_opt->brokers.at(0).host);
-              topic_uri.default_port(Tests::main_opt->brokers.at(0).port);
+              topic_uri.host = Tests::main_opt->brokers.at(0).host;
+              topic_uri.port = Tests::main_opt->brokers.at(0).port;
               LOG(7, "broker: {}  topic: {}  channel: {}", topic_uri.host_port,
                   topic_uri.topic, channel);
               bopt.address = topic_uri.host_port;

--- a/src/tests/uri.cxx
+++ b/src/tests/uri.cxx
@@ -131,3 +131,8 @@ TEST(URI, host_default_topic) {
   ASSERT_EQ(u1.path, "/some-path");
   ASSERT_EQ(u1.topic, "some-path");
 }
+TEST(URI, trim) {
+  URI u1("  //some:123     ");
+  ASSERT_EQ(u1.host, "some");
+  ASSERT_EQ(u1.port, 123);
+}

--- a/src/tests/uri.cxx
+++ b/src/tests/uri.cxx
@@ -24,7 +24,7 @@ TEST(URI, host_port) {
 TEST(URI, host_port_noslashes) {
   URI u1;
   u1.require_host_slashes = false;
-  u1.init("myhost:345");
+  u1.parse("myhost:345");
   ASSERT_EQ(u1.scheme, "");
   ASSERT_EQ(u1.host, "myhost");
   ASSERT_EQ(u1.port, (uint32_t)345);
@@ -36,16 +36,18 @@ TEST(URI, ip_port) {
   ASSERT_EQ(u1.port, (uint32_t)345);
 }
 TEST(URI, scheme_host_port) {
-  URI u1("http://my.host:345");
-  u1.default_port(123);
+  URI u1;
+  u1.port = 123;
+  u1.parse("http://my.host:345");
   ASSERT_EQ(u1.scheme, "http");
   ASSERT_EQ(u1.host, "my.host");
   ASSERT_EQ(u1.host_port, "my.host:345");
   ASSERT_EQ(u1.port, (uint32_t)345);
 }
 TEST(URI, scheme_host_port_default) {
-  URI u1("http://my.host");
-  u1.default_port(123);
+  URI u1;
+  u1.port = 123;
+  u1.parse("http://my.host");
   ASSERT_EQ(u1.scheme, "http");
   ASSERT_EQ(u1.host, "my.host");
   ASSERT_EQ(u1.host_port, "my.host:123");
@@ -121,8 +123,8 @@ TEST(URI, reltopic) {
   ASSERT_EQ(u1.topic, "topic-name.test");
 }
 TEST(URI, host_default_topic) {
-  URI u1("//my.host");
-  u1.default_path("/some-path");
+  URI u1("/some-path");
+  u1.parse("//my.host");
   ASSERT_EQ(u1.scheme, "");
   ASSERT_EQ(u1.host, "my.host");
   ASSERT_EQ(u1.port, (uint32_t)0);

--- a/src/uri.cxx
+++ b/src/uri.cxx
@@ -93,7 +93,25 @@ static vector<string> hostport(string s) {
   return {string(), string(), s};
 }
 
+static string trim(string s) {
+  string::size_type a = 0;
+  while (s.find(" ", a) == a) {
+    ++a;
+  }
+  s = s.substr(a);
+  if (s.empty()) {
+    return s;
+  }
+  a = s.size() - 1;
+  while (s[a] == ' ') {
+    --a;
+  }
+  s = s.substr(0, a + 1);
+  return s;
+}
+
 void URI::parse(string uri) {
+  uri = trim(uri);
   auto proto = protocol(uri);
   if (not proto[0].empty()) {
     scheme = proto[0];

--- a/src/uri.cxx
+++ b/src/uri.cxx
@@ -8,7 +8,6 @@ using std::array;
 using std::move;
 
 static string topic_from_path(string s) {
-  LOG(3, "topic_from_path: {}", s);
   auto p = s.find("/");
   if (p == 0) {
     s = s.substr(1);
@@ -65,7 +64,6 @@ static vector<string> protocol(string s) {
 }
 
 static vector<string> hostport(string s) {
-  LOG(3, "s: {}", s);
   if (s.find("//") != 0) {
     return {string(), string(), s};
   }
@@ -96,7 +94,6 @@ static vector<string> hostport(string s) {
 }
 
 void URI::parse(string uri) {
-  LOG(3, "parse: {}", uri);
   auto proto = protocol(uri);
   if (not proto[0].empty()) {
     scheme = proto[0];
@@ -108,7 +105,6 @@ void URI::parse(string uri) {
     }
   }
   auto hp = hostport(s);
-  LOG(3, "hp: {}  {}  {}", hp[0], hp[1], hp[2]);
   if (not hp[0].empty()) {
     host = hp[0];
   }

--- a/src/uri.cxx
+++ b/src/uri.cxx
@@ -1,129 +1,30 @@
 #include "uri.h"
 #include "logger.h"
-#include <array>
+#include <iostream>
 
 namespace uri {
 
 using std::array;
 using std::move;
-using std::swap;
 
-struct CG {
-  PCREX_SIZE a, b, n;
-  char const *s;
-  std::string substr(char const *p0) { return std::string(p0 + a, n); }
-  std::string substr() { return std::string(s + a, n); }
-};
-
-#if use_pcre2
-MD::MD(PCREX_SPTR subject) : subject(subject) {
-  md = pcre2_match_data_create(16, nullptr);
-  if (!md) {
-    throw std::runtime_error("allocation failed");
+static string topic_from_path(string s) {
+  LOG(3, "topic_from_path: {}", s);
+  auto p = s.find("/");
+  if (p == 0) {
+    s = s.substr(1);
   }
-}
-MD::~MD() { pcre2_match_data_free(md); }
-string MD::substr(int i) {
-  if (!ok)
-    string();
-  if (i >= ncap)
-    string();
-  auto ov = pcre2_get_ovector_pointer(md) + 2 * i;
-  if (ov[0] == PCRE2_UNSET)
-    return string();
-  string::size_type n(ov[1] - ov[0]);
-  if (n > 0)
-    return {(char *)subject + ov[0], n};
-  return string();
-}
-#else
-MD::MD(PCREX_SPTR subject) : subject(subject) {}
-string MD::substr(int i) {
-  if (!ok)
-    string();
-  if (i >= ncap)
-    string();
-  auto ov = ovec.data() + 2 * i;
-  if (ov[0] < 0)
-    return string();
-  string::size_type n(ov[1] - ov[0]);
-  if (n > 0)
-    return {subject + ov[0], n};
-  return string();
-}
-#endif
-
-#if use_pcre2
-void p_regerr(int err) {
-  std::array<unsigned char, 256> s1;
-  auto n = pcre2_get_error_message(err, s1.data(), s1.size());
-  fmt::print("err in regex: [{}, {}] {:.{}}\n", err, n, (char *)s1.data(), n);
-}
-#else
-void p_regerr(char const *s1) { fmt::print("err in regex: {}\n", s1); }
-#endif
-
-#if use_pcre2
-Re::Re(char const *s) { init((rchar const *)s); }
-Re::Re(rchar const *s) { init(s); }
-void Re::init(rchar const *s) {
-  int err = 0;
-  pcre_erroff_t errpos = 0;
-  re = pcre2_compile_8(s, PCRE2_ZERO_TERMINATED, 0, &err, &errpos, nullptr);
-  if (!re) {
-    p_regerr(err);
-    throw std::runtime_error("can not compile regex");
+  p = s.find("/");
+  if (p == string::npos) {
+    return s;
   }
-}
-Re::~Re() { pcre2_code_free(re); }
-MD Re::match(string const &s) {
-  MD md((PCREX_SPTR)s.data());
-  auto x =
-      pcre2_match(re, (PCREX_SPTR)s.data(), s.size(), 0, 0, md.md, nullptr);
-  if (x >= 0) {
-    md.ok = true;
+  else {
+    if (p == 0) {
+      return s.substr(1);
+    }
+    else {
+      return string();
+    }
   }
-  return md;
-}
-#else
-Re::Re(rchar const *s) {
-  if (!s) {
-    throw std::runtime_error("empty regular expression");
-  }
-  char const *errptr = nullptr;
-  pcre_erroff_t errpos = 0;
-  re = pcre_compile(s, 0, &errptr, &errpos, nullptr);
-  if (!re) {
-    p_regerr(errptr);
-    throw std::runtime_error("can not compile regex");
-  }
-}
-Re::~Re() { pcre_free(re); }
-MD Re::match(string const &s) {
-  MD md(s.data());
-  auto x = pcre_exec(re, nullptr, s.data(), s.size(), 0, 0, md.ovec.data(),
-                     md.ovec.size());
-  if (x > 0) {
-    md.ok = true;
-    md.ncap = x;
-  }
-  return md;
-}
-#endif
-Re::Re(Re &&x) { swap(*this, x); }
-Re &Re::operator=(Re &&x) {
-  swap(*this, x);
-  return *this;
-}
-void swap(Re &x, Re &y) { swap(x.re, y.re); }
-
-static_ini::static_ini() {
-  URI::re1 = Re((rchar *)"^\\s*(([a-z]+):)?//(([-._A-Za-z0-9]+)(:([0-9]+))?)(/"
-                         "[-./_A-Za-z0-9]*)?\\s*$");
-  URI::re_host_no_slashes = Re(
-      (rchar *)"^\\s*(([-._A-Za-z0-9]+)(:([0-9]+))?)(/[-./_A-Za-z0-9]*)?\\s*$");
-  URI::re_no_host = Re((rchar *)"^/?([-./_A-Za-z0-9]*)$");
-  URI::re_topic = Re((rchar *)"^/?([-._A-Za-z0-9]+)$");
 }
 
 void URI::update_deps() {
@@ -132,83 +33,92 @@ void URI::update_deps() {
   } else {
     host_port = host;
   }
-  // check if the path could be a valid topic
-  auto md = re_topic.match(path);
-  if (md.ok) {
-    topic = md.substr(1);
+  auto t = topic_from_path(path);
+  if (not t.empty()) {
+    topic = t;
   }
 }
-
-URI::~URI() {}
 
 URI::URI() {}
 
-URI::URI(std::string uri) { init(uri); }
+URI::URI(string uri) { parse(uri); }
 
-void URI::init(std::string uri) {
-  using std::vector;
-  using std::string;
-  bool match = false;
-  if (!match) {
-    auto md = re1.match(uri);
-    if (md.ok) {
-      match = true;
-      scheme = md.substr(2);
-      host = md.substr(4);
-      auto port_s = md.substr(6);
-      if (port_s.size() > 0) {
-        port = strtoul(port_s.data(), nullptr, 10);
+static bool is_alpha(string s) {
+  for (auto c : s) {
+    if (c < 'a' or c > 'z') {
+      return false;
+    }
+  }
+  return true;
+}
+
+static vector<string> protocol(string s) {
+  auto slashes = s.find("://");
+  if (slashes == string::npos or slashes == 0) {
+    return {string(), s};
+  }
+  auto proto = s.substr(0, slashes);
+  if (not is_alpha(proto)) {
+    return {string(), s};
+  }
+  return {proto, s.substr(slashes+1, string::npos)};
+}
+
+static vector<string> hostport(string s) {
+  LOG(3, "s: {}", s);
+  if (s.find("//") != 0) {
+    return {string(), string(), s};
+  }
+  auto slash = s.find("/", 2);
+  auto colon = s.find(":", 2);
+  if (colon == string::npos) {
+    if (slash == string::npos) {
+      return {s.substr(2), string(), string()};
+    }
+    else {
+      return {s.substr(2, slash-2), string(), s.substr(slash)};
+    }
+  }
+  else {
+    if (slash == string::npos) {
+      return {s.substr(2, colon-2), s.substr(colon+1), string()};
+    }
+    else {
+      if (colon < slash) {
+        return {s.substr(2, colon-2), s.substr(colon+1, slash-colon-1), s.substr(slash)};
       }
-      path = md.substr(7);
-    }
-  }
-  if (!match && !require_host_slashes) {
-    auto md = re_host_no_slashes.match(uri);
-    if (md.ok) {
-      match = true;
-      host = md.substr(2);
-      auto port_s = md.substr(4);
-      if (port_s.size() > 0) {
-        port = strtoul(port_s.data(), nullptr, 10);
+      else {
+        return {s.substr(2, slash-2), string(), s.substr(slash)};
       }
-      path = md.substr(5);
     }
   }
-  if (!match) {
-    auto md = re_no_host.match(uri);
-    if (md.ok) {
-      match = true;
-      path = md.substr(0);
+  return {string(), string(), s};
+}
+
+void URI::parse(string uri) {
+  LOG(3, "parse: {}", uri);
+  auto proto = protocol(uri);
+  if (not proto[0].empty()) {
+    scheme = proto[0];
+  }
+  auto s = proto[1];
+  if (not require_host_slashes) {
+    if (s.find("/") != 0) {
+      s = "//" + s;
     }
   }
-  update_deps();
-}
-
-Re URI::re1(".");
-Re URI::re_host_no_slashes(".");
-Re URI::re_no_host(".");
-Re URI::re_topic(".");
-
-void URI::default_port(int port_) {
-  if (port == 0) {
-    port = port_;
+  auto hp = hostport(s);
+  LOG(3, "hp: {}  {}  {}", hp[0], hp[1], hp[2]);
+  if (not hp[0].empty()) {
+    host = hp[0];
+  }
+  if (not hp[1].empty()) {
+    port = strtoul(hp[1].data(), nullptr, 10);
+  }
+  if (not hp[2].empty()) {
+    path = hp[2];
   }
   update_deps();
 }
 
-void URI::default_path(std::string path_) {
-  if (path.size() == 0) {
-    path = path_;
-  }
-  update_deps();
-}
-
-void URI::default_host(std::string host_) {
-  if (host.size() == 0) {
-    host = host_;
-  }
-  update_deps();
-}
-
-static_ini URI::compiled;
 }

--- a/src/uri.h
+++ b/src/uri.h
@@ -1,98 +1,45 @@
 #pragma once
 
-#ifndef use_pcre2
-#define use_pcre2 0
-#endif
 #include <array>
+#include <vector>
 #include <string>
-#if use_pcre2
-#define PCRE2_CODE_UNIT_WIDTH 8
-#include <pcre2.h>
-#else
-#include <pcre.h>
-#endif
-#if HAVE_GTEST
-#include <gtest/gtest.h>
-#endif
 
 namespace uri {
 
 using std::array;
+using std::vector;
 using std::string;
 
-#if use_pcre2
-using rchar = unsigned char;
-using pcre_re_t = pcre2_code;
-using pcre_erroff_t = PCRE2_SIZE;
-using PCREX_SIZE = PCRE2_SIZE;
-using PCREX_SPTR = PCRE2_SPTR;
-#else
-using rchar = char;
-using pcre_re_t = pcre;
-using pcre_erroff_t = int;
-using PCREX_SIZE = int;
-using PCREX_SPTR = char const *;
-#endif
-
-struct MD {
-  MD(PCREX_SPTR subject);
-  string substr(int i);
-  PCREX_SPTR subject;
-  bool ok = false;
-  int ncap = 0;
-#if use_pcre2
-  ~MD();
-  pcre2_match_data *md;
-  array<PCREX_SIZE, 24> ovec;
-#else
-  array<int, 24> ovec;
-#endif
-};
-
-struct Re {
-#if use_pcre2
-  Re(char const *s);
-#endif
-  Re(rchar const *s);
-  ~Re();
-  Re(Re &&);
-  Re &operator=(Re &&);
-  void init(rchar const *s);
-  MD match(string const &s);
-  pcre_re_t *re = nullptr;
-  friend void swap(Re &x, Re &y);
-};
-
-struct static_ini {
-  static_ini();
-};
-
+/// Thin parser for URIs.
 class URI {
 public:
-  using uchar = unsigned char;
-  ~URI();
+  /// Creates a default URI with all members empty. You can (should) run
+  /// URI::parse to fill it
   URI();
-  URI(std::string uri);
-  void init(std::string uri);
-  void default_host(std::string host);
-  void default_port(int port);
-  void default_path(std::string path);
-  bool is_kafka_with_topic() const;
+  /// Creates and parses the given URI
+  URI(string uri);
+  /// Parses the given `uri`
+  void parse(string uri);
+  /// Given a `http://www.example.com` scheme will contain `http`
   std::string scheme;
+  /// Just the parsed hostname
   std::string host;
+  /// If port was specified (or already non-zero before `URI::parse`) it
+  /// contains `host:port`
   std::string host_port;
+  /// The port number if specified, or zero to indicate that the port is not
+  /// specified
   uint32_t port = 0;
+  /// The path of the URL
   std::string path;
+  /// If the path can be a valid Kafka topic name, then it is non-empty
   std::string topic;
+  /// Whether we require two slashes before the hostname, as required by the
+  /// standard.  Otherwise ambiguous because `host/path` could also be a
+  /// `path/path`.
   bool require_host_slashes = true;
 
 private:
-  static Re re1;
-  static Re re_host_no_slashes;
-  static Re re_no_host;
-  static Re re_topic;
-  static static_ini compiled;
   void update_deps();
-  friend struct static_ini;
 };
 }


### PR DESCRIPTION
Some build environments still have only ancient compilers installed.
There is a need to solve this immediately.
Therefore, remove usage of regular expressions from project as a step in that direction.