### PR TITLE
Added Jenkins CppCheck reporting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -216,7 +216,7 @@ def get_pipeline(image_key) {
                 if (image_key == clangformat_os) {
                     docker_formatting(image_key)
                     docker_cppcheck(image_key)
-                    step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']])
+                    step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']]])
                 } else {
                     docker_build(image_key)
                     if (image_key == test_and_coverage_os) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -196,7 +196,6 @@ def docker_cppcheck(image_key) {
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/forward-epics-to-kafka/${test_output} ."
-        junit "${test_output}"
     } catch (e) {
         failure_function(e, "Cppcheck step for (${container_name(image_key)}) failed")
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -196,6 +196,7 @@ def docker_cppcheck(image_key) {
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/forward-epics-to-kafka/cppcheck.xml ."
+        junit "${test_output}"
     } catch (e) {
         failure_function(e, "Cppcheck step for (${container_name(image_key)}) failed")
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,6 +214,7 @@ def get_pipeline(image_key) {
 
                 if (image_key == clangformat_os) {
                     docker_formatting(image_key)
+                    docker_cppcheck(image_key)
                 } else {
                     docker_build(image_key)
                     if (image_key == test_and_coverage_os) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,7 +192,7 @@ def docker_cppcheck(image_key) {
         def test_output = "cppcheck.xml"
         def cppcheck_script = """
                         cd forward-epics-to-kafka
-                        cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ 2> build/${test_output}
+                        cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ 
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/build ./"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,6 +186,21 @@ def docker_coverage(image_key) {
     }
 }
 
+def docker_cppcheck(image_key) {
+    try {
+        def custom_sh = images[image_key]['sh']
+        def test_output = "cppcheck.xml"
+        def cppcheck_script = """
+                        cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ 2> ${test_output}
+                    """
+        sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
+        sh "docker cp ${container_name(image_key)}:/home/jenkins/build ./"
+        junit "build/${test_output}"
+    } catch (e) {
+        failure_function(e, "Cppcheck step for (${container_name(image_key)}) failed")
+    }
+}
+
 def get_pipeline(image_key) {
     return {
         stage("${image_key}") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,9 +192,9 @@ def docker_cppcheck(image_key) {
         def test_output = "cppcheck.xml"
         def cppcheck_script = """
                         cd forward-epics-to-kafka
-                        cppcheck --enable=all --inconclusive --xml --xml-version=2 src/
+                        cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ | 2> build/${test_output}
                     """
-        sh "docker exec ${container_name(image_key)} ${custom_sh} -ic \"${cppcheck_script}\" 2> ${test_output}"
+        sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/build ./"
         junit "build/${test_output}"
     } catch (e) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,10 +192,10 @@ def docker_cppcheck(image_key) {
         def test_output = "cppcheck.xml"
         def cppcheck_script = """
                         cd forward-epics-to-kafka
-                        cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ 2> ../${test_output}
+                        cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ 2> ${test_output}
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
-        sh "docker cp ${container_name(image_key)}:${test_output} ."
+        sh "docker cp ${container_name(image_key)}:/home/jenkins/build/forward-epics-to-kafka/cppcheck.xml ."
     } catch (e) {
         failure_function(e, "Cppcheck step for (${container_name(image_key)}) failed")
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,7 +192,7 @@ def docker_cppcheck(image_key) {
         def test_output = "cppcheck.xml"
         def cppcheck_script = """
                         cd forward-epics-to-kafka
-                        cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ | 2> ../${test_output}
+                        cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ 2> ../${test_output}
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/build ./"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,7 +195,7 @@ def docker_cppcheck(image_key) {
                         cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ 2> ../${test_output}
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
-        sh "docker cp ${container_name(image_key)}:/home/jenkins/build ./"
+        sh "docker cp ${container_name(image_key)}:${test_output} ."
     } catch (e) {
         failure_function(e, "Cppcheck step for (${container_name(image_key)}) failed")
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,22 +8,22 @@ epics_dir = "/opt/epics"
 epics_profile_file = "/etc/profile.d/ess_epics_env.sh"
 
 images = [
-        // 'centos7-gcc6': [
-        //         'name': 'essdmscdm/centos7-gcc6-build-node:2.1.0',
-        //         'sh'  : '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash'
-        // ],
+        'centos7-gcc6': [
+                'name': 'essdmscdm/centos7-gcc6-build-node:2.1.0',
+                'sh'  : '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash'
+        ],
         'fedora25'    : [
                 'name': 'essdmscdm/fedora25-build-node:1.0.0',
                 'sh'  : 'sh'
         ],
-        // 'ubuntu1604'  : [
-        //         'name': 'essdmscdm/ubuntu16.04-build-node:2.1.0',
-        //         'sh'  : 'sh'
-        // ],
-        // 'ubuntu1710': [
-        //         'name': 'essdmscdm/ubuntu17.10-build-node:2.0.0',
-        //         'sh': 'sh'
-        // ]
+        'ubuntu1604'  : [
+                'name': 'essdmscdm/ubuntu16.04-build-node:2.1.0',
+                'sh'  : 'sh'
+        ],
+        'ubuntu1710': [
+                'name': 'essdmscdm/ubuntu17.10-build-node:2.0.0',
+                'sh': 'sh'
+        ]
 ]
 
 base_container_name = "${project}-${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
@@ -296,7 +296,7 @@ node('docker && eee') {
       def image_key = x
       builders[image_key] = get_pipeline(image_key)
     }
-    //builders['windows10'] = get_win10_pipeline()
+    builders['windows10'] = get_win10_pipeline()
 
     parallel builders
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,9 +192,9 @@ def docker_cppcheck(image_key) {
         def test_output = "cppcheck.xml"
         def cppcheck_script = """
                         cd forward-epics-to-kafka
-                        cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ 
+                        cppcheck --enable=all --inconclusive --xml --xml-version=2 src/
                     """
-        sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
+        sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\" 2> cppcheck.xml"
         sh "docker cp ${container_name(image_key)}:/home/jenkins/build ./"
         junit "build/${test_output}"
     } catch (e) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,7 +192,7 @@ def docker_cppcheck(image_key) {
         def test_output = "cppcheck.xml"
         def cppcheck_script = """
                         cd forward-epics-to-kafka
-                        cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ | 2> build/${test_output}
+                        cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ | 2> ../${test_output}
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/build ./"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,7 +195,7 @@ def docker_cppcheck(image_key) {
                         cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ 2> ${test_output}
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
-        sh "docker cp ${container_name(image_key)}:/home/jenkins/build/forward-epics-to-kafka/cppcheck.xml ."
+        sh "docker cp ${container_name(image_key)}:/home/jenkins/forward-epics-to-kafka/cppcheck.xml ."
     } catch (e) {
         failure_function(e, "Cppcheck step for (${container_name(image_key)}) failed")
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,22 +8,22 @@ epics_dir = "/opt/epics"
 epics_profile_file = "/etc/profile.d/ess_epics_env.sh"
 
 images = [
-        'centos7-gcc6': [
-                'name': 'essdmscdm/centos7-gcc6-build-node:2.1.0',
-                'sh'  : '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash'
-        ],
+        // 'centos7-gcc6': [
+        //         'name': 'essdmscdm/centos7-gcc6-build-node:2.1.0',
+        //         'sh'  : '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash'
+        // ],
         'fedora25'    : [
                 'name': 'essdmscdm/fedora25-build-node:1.0.0',
                 'sh'  : 'sh'
         ],
-        'ubuntu1604'  : [
-                'name': 'essdmscdm/ubuntu16.04-build-node:2.1.0',
-                'sh'  : 'sh'
-        ],
-        'ubuntu1710': [
-                'name': 'essdmscdm/ubuntu17.10-build-node:2.0.0',
-                'sh': 'sh'
-        ]
+        // 'ubuntu1604'  : [
+        //         'name': 'essdmscdm/ubuntu16.04-build-node:2.1.0',
+        //         'sh'  : 'sh'
+        // ],
+        // 'ubuntu1710': [
+        //         'name': 'essdmscdm/ubuntu17.10-build-node:2.0.0',
+        //         'sh': 'sh'
+        // ]
 ]
 
 base_container_name = "${project}-${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
@@ -295,7 +295,7 @@ node('docker && eee') {
       def image_key = x
       builders[image_key] = get_pipeline(image_key)
     }
-    builders['windows10'] = get_win10_pipeline()
+    //builders['windows10'] = get_win10_pipeline()
 
     parallel builders
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -191,8 +191,8 @@ def docker_cppcheck(image_key) {
         def custom_sh = images[image_key]['sh']
         def test_output = "cppcheck.xml"
         def cppcheck_script = """
-                        pwd
-                        cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ 2> ${test_output}
+                        cd forward-epics-to-kafka
+                        cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ 2> build/${test_output}
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/build ./"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -196,7 +196,6 @@ def docker_cppcheck(image_key) {
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/build ./"
-        junit "build/${test_output}"
     } catch (e) {
         failure_function(e, "Cppcheck step for (${container_name(image_key)}) failed")
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -194,7 +194,7 @@ def docker_cppcheck(image_key) {
                         cd forward-epics-to-kafka
                         cppcheck --enable=all --inconclusive --xml --xml-version=2 src/
                     """
-        sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\" 2> cppcheck.xml"
+        sh "docker exec ${container_name(image_key)} ${custom_sh} -ic \"${cppcheck_script}\" 2> ${test_output}"
         sh "docker cp ${container_name(image_key)}:/home/jenkins/build ./"
         junit "build/${test_output}"
     } catch (e) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -191,6 +191,7 @@ def docker_cppcheck(image_key) {
         def custom_sh = images[image_key]['sh']
         def test_output = "cppcheck.xml"
         def cppcheck_script = """
+                        pwd
                         cppcheck --enable=all --inconclusive --xml --xml-version=2 src/ 2> ${test_output}
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""

--- a/src/EpicsClient.cpp
+++ b/src/EpicsClient.cpp
@@ -168,7 +168,7 @@ EpicsClientFactoryInit::~EpicsClientFactoryInit() {
 
 class EpicsClient_impl {
 public:
-  EpicsClient_impl(EpicsClient *epics_client);
+  explicit EpicsClient_impl(EpicsClient *epics_client);
   ~EpicsClient_impl();
   int init(string epics_channel_provider_type);
   int monitoring_start();


### PR DESCRIPTION
This adds CppCheck as part of the Jenkins build.
The results can then be viewed in Jenkins, for example: https://jenkins.esss.dk/dm/job/ess-dmsc/job/forward-epics-to-kafka/job/jenkins_cppcheck_test/18/warnings2Result/
