### PR TITLE
Forward scalar string PVs

### DIFF
--- a/src/schemas/f142/f142.cpp
+++ b/src/schemas/f142/f142.cpp
@@ -239,7 +239,6 @@ public:
         Builder->CreateString(Value.data(), Value.size());
     StringBuilder ValueBuilder(*Builder);
     ValueBuilder.add_value(FlatbufferedValueString);
-    LOG(Sev::Critical, "DONE: {}", Value);
     return {Value::String, ValueBuilder.Finish().Union()};
   }
 };

--- a/src/schemas/f142/f142.cpp
+++ b/src/schemas/f142/f142.cpp
@@ -98,6 +98,10 @@ template <>
 struct BuilderType_to_Enum_Value<DoubleBuilder> : public Enum_Value_Base {
   static Value v() { return Value::Double; }
 };
+template <>
+struct BuilderType_to_Enum_Value<StringBuilder> : public Enum_Value_Base {
+  static Value v() { return Value::String; }
+};
 
 template <>
 struct BuilderType_to_Enum_Value<ArrayByteBuilder> : public Enum_Value_Base {
@@ -239,7 +243,8 @@ public:
         Builder->CreateString(Value.data(), Value.size());
     StringBuilder ValueBuilder(*Builder);
     ValueBuilder.add_value(FlatbufferedValueString);
-    return {Value::String, ValueBuilder.Finish().Union()};
+    return {BuilderType_to_Enum_Value<StringBuilder>::v(),
+            ValueBuilder.Finish().Union()};
   }
 };
 

--- a/src/schemas/f142/f142.cpp
+++ b/src/schemas/f142/f142.cpp
@@ -276,6 +276,8 @@ Value_t make_Value_scalar(flatbuffers::FlatBufferBuilder &builder,
   case S::pvDouble:
     return Make_Scalar<double>::convert(&builder, field);
   case S::pvString:
+    return MakeScalarString::convert(&builder, field);
+  default:
     ++statistics.err_not_implemented_yet;
     break;
   }

--- a/src/schemas/f142/f142.cpp
+++ b/src/schemas/f142/f142.cpp
@@ -142,34 +142,21 @@ struct BuilderType_to_Enum_Value<ArrayDoubleBuilder> : public Enum_Value_Base {
 
 template <typename T0> class Make_Scalar {
 public:
-  using T1 = typename std::conditional<
-      std::is_same<T0, epics::pvData::boolean>::value, ByteBuilder,
-      typename std::conditional<
-          std::is_same<T0, int8_t>::value, ByteBuilder,
-          typename std::conditional<
-              std::is_same<T0, int16_t>::value, ShortBuilder,
-              typename std::conditional<
-                  std::is_same<T0, int32_t>::value, IntBuilder,
-                  typename std::conditional<
-                      std::is_same<T0, int64_t>::value, LongBuilder,
-                      typename std::conditional<
-                          std::is_same<T0, uint8_t>::value, UByteBuilder,
-                          typename std::conditional<
-                              std::is_same<T0, uint16_t>::value, UShortBuilder,
-                              typename std::conditional<
-                                  std::is_same<T0, uint32_t>::value,
-                                  UIntBuilder,
-                                  typename std::conditional<
-                                      std::is_same<T0, uint64_t>::value,
-                                      ULongBuilder,
-                                      typename std::conditional<
-                                          std::is_same<T0, float>::value,
-                                          FloatBuilder,
-                                          typename std::conditional<
-                                              std::is_same<T0, double>::value,
-                                              DoubleBuilder, std::nullptr_t>::
-                                              type>::type>::type>::type>::
-                              type>::type>::type>::type>::type>::type>::type;
+  // clang-format off
+  using T1 =
+    typename std::conditional<std::is_same<T0, epics::pvData::boolean>::value, ByteBuilder,
+    typename std::conditional<std::is_same<T0,   int8_t>::value, ByteBuilder,
+    typename std::conditional<std::is_same<T0,  int16_t>::value, ShortBuilder,
+    typename std::conditional<std::is_same<T0,  int32_t>::value, IntBuilder,
+    typename std::conditional<std::is_same<T0,  int64_t>::value, LongBuilder,
+    typename std::conditional<std::is_same<T0,  uint8_t>::value, UByteBuilder,
+    typename std::conditional<std::is_same<T0, uint16_t>::value, UShortBuilder,
+    typename std::conditional<std::is_same<T0, uint32_t>::value, UIntBuilder,
+    typename std::conditional<std::is_same<T0, uint64_t>::value, ULongBuilder,
+    typename std::conditional<std::is_same<T0,    float>::value, FloatBuilder,
+    typename std::conditional<std::is_same<T0,   double>::value, DoubleBuilder,
+    std::nullptr_t>::type>::type>::type>::type>::type>::type>::type>::type>::type>::type>::type;
+  // clang-format on
 
   static Value_t convert(flatbuffers::FlatBufferBuilder *builder,
                          epics::pvData::PVScalar *field_) {

--- a/src/schemas/f142/f142.cpp
+++ b/src/schemas/f142/f142.cpp
@@ -228,6 +228,22 @@ public:
   }
 };
 
+class MakeScalarString {
+public:
+  static Value_t convert(flatbuffers::FlatBufferBuilder *Builder,
+                         epics::pvData::PVScalar *PVScalarValue) {
+    auto PVScalarString =
+        static_cast<epics::pvData::PVScalarValue<std::string> *>(PVScalarValue);
+    std::string Value = PVScalarString->get();
+    auto FlatbufferedValueString =
+        Builder->CreateString(Value.data(), Value.size());
+    StringBuilder ValueBuilder(*Builder);
+    ValueBuilder.add_value(FlatbufferedValueString);
+    LOG(Sev::Critical, "DONE: {}", Value);
+    return {Value::String, ValueBuilder.Finish().Union()};
+  }
+};
+
 } // end namespace PVStructureToFlatBufferN
 
 Value_t make_Value_scalar(flatbuffers::FlatBufferBuilder &builder,


### PR DESCRIPTION
### Description of work

- Added forwarding of scalar string PVs for flatbuffer schema `f142`

Corresponding filewriter support added in `kafka-to-nexus` branch `write_f142_scalar_strings`.

### Issue

Updates #82 

Forwarding of string arrays is coming in separate PR.

### Acceptance Criteria

Forwarding a scalar string PV via `f142` schema should produce flatbuffer messages which contain the updated string.

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
