### PR TITLE
Making unit tests build by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -274,7 +274,7 @@ def get_win10_pipeline() {
 
 	 stage("win10: Build") {
            bat """cd _build
-	     cmake .. -G \"Visual Studio 15 2017 Win64\" -DCMAKE_BUILD_TYPE=Release
+	     cmake .. -G \"Visual Studio 15 2017 Win64\" -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=FALSE
 	     cmake --build .
 	     """
         }  // stage

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,7 @@ def docker_cmake(image_key) {
         def configure_script = """
                     cd build
                     ${configure_epics}
-                    cmake ../${project} -DREQUIRE_GTEST=ON ${coverage_on}
+                    cmake ../${project} ${coverage_on}
                 """
 
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${configure_script}\""

--- a/README.md
+++ b/README.md
@@ -55,11 +55,12 @@ remotes can be listed with `conan remote list`.
 Assuming you have `make`:
 
 ```
-cmake <path-to-source> [-DREQUIRE_GTEST=TRUE] [-DCONAN_DISABLE=TRUE]
+cmake <path-to-source> [-DCONAN_DISABLE=TRUE]
 make
 make docs  # optional
 ```
 
+To skip building the tests target pass cmake `-DBUILD_TESTS=FALSE`
 
 #### Running on macOS
 

--- a/build-script/invoke-cmake-from-jenkinsfile.sh
+++ b/build-script/invoke-cmake-from-jenkinsfile.sh
@@ -8,4 +8,3 @@ cmake ../code \
 -DCMAKE_INCLUDE_PATH=../googletest\;../streaming-data-types\;$DM_ROOT/usr/include\;$DM_ROOT/usr/lib \
 -DCMAKE_LIBRARY_PATH=$DM_ROOT/usr/lib \
 -Dflatc=$DM_ROOT/usr/bin/flatc \
--DREQUIRE_GTEST=1

--- a/build-script/jenkins-build.sh
+++ b/build-script/jenkins-build.sh
@@ -70,4 +70,4 @@ echo "-----------------------------------------------------"
 mkdir -p build
 mkdir -p install
 cd build
-cmake -DCMAKE_INCLUDE_PATH=../repos/streaming-data-types -DCMAKE_INSTALL_PREFIX=`cd ../install; pwd` -DREQUIRE_GTEST=1 ../repos/forward-epics-to-kafka  &&  make VERBOSE=1
+cmake -DCMAKE_INCLUDE_PATH=../repos/streaming-data-types -DCMAKE_INSTALL_PREFIX=`cd ../install; pwd` ../repos/forward-epics-to-kafka  &&  make VERBOSE=1

--- a/cmake/FindGoogletest.cmake
+++ b/cmake/FindGoogletest.cmake
@@ -10,7 +10,7 @@ function(setup_googletest_from_repository)
 	add_subdirectory(${path_googletest_repository} googletest)
 endfunction()
 
-set(REQUIRE_GTEST FALSE CACHE BOOL "Require Google Test")
+set(REQUIRE_GTEST TRUE CACHE BOOL "Require Google Test")
 
 if (REQUIRE_GTEST)
 	find_library(GMOCK_MAIN_LIB NAMES gmock_main gmock_maind)

--- a/cmake/FindGoogletest.cmake
+++ b/cmake/FindGoogletest.cmake
@@ -10,9 +10,9 @@ function(setup_googletest_from_repository)
 	add_subdirectory(${path_googletest_repository} googletest)
 endfunction()
 
-set(REQUIRE_GTEST TRUE CACHE BOOL "Require Google Test")
+set(BUILD_TESTS TRUE CACHE BOOL "Require Google Test")
 
-if (REQUIRE_GTEST)
+if (BUILD_TESTS)
 	find_library(GMOCK_MAIN_LIB NAMES gmock_main gmock_maind)
 	if (GMOCK_MAIN_LIB)
 		message(STATUS "Google Test found")


### PR DESCRIPTION
### Description of work

Just changing the default value of REQUIRE_GTEST in the cmake so that the tests will be build by default. If REQUIRE_GTEST is set to false it will no longer build the test target. 

### Issue

Closes #101 

### Acceptance Criteria

Check running the forward-epics-to-kafka target builds tests target by default. 

### Unit Tests

No unit tests modified. 

### Other

---

## Code Review (To be filled in by the reviewer only)

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
