### PR TITLE
JIRA DM-936 incorporate essiip-deployment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,17 @@ if(CMAKE_COMPILER_IS_GNUCXX AND COV)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_COVERAGE}")
 endif()
 
+if(CMAKE_BUILD_TYPE MATCHES "Release")
+  set(OUTPUT_DIRS "")
+else()
+  set(OUTPUT_DIRS "NO_OUTPUT_DIRS")
+endif()
+
 if(NOT CONAN_DISABLE)
     include(${CMAKE_MODULE_PATH}/conan.cmake)
     conan_cmake_run(CONANFILE conan/conanfile.txt
             PROFILE default
-            BASIC_SETUP NO_OUTPUT_DIRS
+            BASIC_SETUP ${OUTPUT_DIRS}
             BUILD_TYPE "None"
             BUILD outdated)
 endif()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,7 +133,7 @@ def docker_build(image_key) {
         def custom_sh = images[image_key]['sh']
         def build_script = """
                       cd build
-                      . ./activate_build.sh
+                      . ./activate_run.sh
                       make VERBOSE=1
                   """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${build_script}\""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -218,7 +218,7 @@ def docker_coverage(image_key) {
                 export WORKSPACE='.' && \
                 export JENKINS_URL=${JENKINS_URL} && \
                 pip install --user codecov && \
-                python -m codecov -t ${TOKEN} --commit ${scm_vars.GIT_COMMIT} -f ../build/coverage.info && \
+                python -m codecov -t ${TOKEN} --commit ${scm_vars.GIT_COMMIT} -f ../build/coverage.info
                 """
             sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${codecov_upload_script}\""
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,12 +176,12 @@ def docker_archive(image_key) {
         def custom_sh = images[image_key]['sh']
         def archive_output = "${project}-${image_key}.tar.gz"
         def archive_script = """
-                    cd build
-                    rm -rf forward-epics-to-kafka; mkdir forward-epics-to-kafka
-                    mkdir forward-epics-to-kafka/bin
-                    cp ./bin/forward-epics-to-kafka forward-epics-to-kafka/bin/
-                    cp -r ./lib forward-epics-to-kafka/
-                    cp -r ./licenses forward-epics-to-kafka/
+                    cd build && \
+                    rm -rf forward-epics-to-kafka; mkdir forward-epics-to-kafka && \
+                    mkdir -p forward-epics-to-kafka/bin && \
+                    cp ./bin/forward-epics-to-kafka forward-epics-to-kafka/bin/ && \
+                    cp -r ./lib forward-epics-to-kafka/ && \
+                    cp -r ./licenses forward-epics-to-kafka/ && \
                     tar czf ${archive_output} forward-epics-to-kafka
                 """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${archive_script}\""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,7 +133,6 @@ def docker_build(image_key) {
         def custom_sh = images[image_key]['sh']
         def build_script = """
                       cd build
-                      . ./activate_run.sh
                       make VERBOSE=1
                   """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${build_script}\""
@@ -147,7 +146,6 @@ def docker_test(image_key, test_dir) {
         def custom_sh = images[image_key]['sh']
         def test_script = """
                         cd build
-                        . ./activate_run.sh
                         ./${test_dir}/tests
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${test_script}\""
@@ -198,7 +196,6 @@ def docker_coverage(image_key) {
         def test_output = "TestResults.xml"
         def coverage_script = """
                         cd build
-                        . ./activate_run.sh
                         ./tests/tests -- --gtest_output=xml:${test_output}
                         make coverage
                         lcov --directory . --capture --output-file coverage.info

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,7 @@ def docker_cmake(image_key) {
 
         def configure_script = """
                     cd build && \
-                    ${configure_epics} && \
+                    ${configure_epics} \
                     cmake ../${project} ${coverage_on}
                 """
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,6 +146,7 @@ def docker_test(image_key, test_dir) {
         def custom_sh = images[image_key]['sh']
         def test_script = """
                         cd build
+                        . ./activate_run.sh
                         ./${test_dir}/tests
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${test_script}\""
@@ -196,10 +197,12 @@ def docker_coverage(image_key) {
         def test_output = "TestResults.xml"
         def coverage_script = """
                         cd build
+                        . ./activate_run.sh
                         ./tests/tests -- --gtest_output=xml:${test_output}
                         make coverage
                         lcov --directory . --capture --output-file coverage.info
                         lcov --remove coverage.info '*_generated.h' '*/src/date/*' '*/.conan/data/*' '*/usr/*' --output-file coverage.info
+                        . ./deactivate_run.sh
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${coverage_script}\""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/build ./"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,11 +96,14 @@ def docker_cmake(image_key) {
         if (image_key == eee_os) {
             // Only use the host machine's EPICS environment on eee_os
             configure_epics = ". ${epics_profile_file}"
+        } else {
+            // A problem is caused by "&& \" if left empty
+            configure_epics = "true"
         }
 
         def configure_script = """
                     cd build && \
-                    ${configure_epics} \
+                    ${configure_epics} && \
                     cmake ../${project} ${coverage_on}
                 """
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,6 +133,7 @@ def docker_build(image_key) {
         def custom_sh = images[image_key]['sh']
         def build_script = """
                       cd build
+                      . ./activate_build.sh
                       make VERBOSE=1
                   """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${build_script}\""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -185,7 +185,7 @@ def docker_archive(image_key) {
                     tar czf ${archive_output} forward-epics-to-kafka
                 """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${archive_script}\""
-        sh "docker cp ${container_name(image_key)}:/home/jenkins/${archive_output} ./"
+        sh "docker cp ${container_name(image_key)}:/home/jenkins/build/${archive_output} ./"
         archiveArtifacts "${archive_output}"
     } catch (e) {
         failure_function(e, "Test step for (${container_name(image_key)}) failed")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,19 @@
 project = "forward-epics-to-kafka"
 clangformat_os = "fedora25"
-test_and_coverage_os = "centos7-gcc6"
-archive_os = "centos7-gcc6"
-eee_os = "centos7-gcc6"
+test_and_coverage_os = "centos7"
+release_os = "centos7-release"
+eee_os = "centos7"
 
 epics_dir = "/opt/epics"
 epics_profile_file = "/etc/profile.d/ess_epics_env.sh"
 
 images = [
-        'centos7-gcc6': [
-                'name': 'essdmscdm/centos7-gcc6-build-node:2.1.0',
+        'centos7': [
+                'name': 'essdmscdm/centos7-build-node:3.0.0',
+                'sh'  : '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash'
+        ],
+        'centos7-release': [
+                'name': 'essdmscdm/centos7-build-node:3.0.0',
                 'sh'  : '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash'
         ],
         'fedora25'    : [
@@ -44,6 +48,8 @@ def Object create_container(image_key) {
     def container = image.run("\
         --name ${container_name(image_key)} \
         --tty \
+        --cpus=2 \
+        --memory=4GB \
         --network=host \
         --env http_proxy=${env.http_proxy} \
         --env https_proxy=${env.https_proxy} \
@@ -104,6 +110,24 @@ def docker_cmake(image_key) {
     }
 }
 
+def docker_cmake_release(image_key) {
+    try {
+        def custom_sh = images[image_key]['sh']
+        def configure_script = """
+                        cd build && \
+                        cmake ../${project} \
+                            -DCMAKE_BUILD_TYPE=Release \
+                            -DCMAKE_SKIP_RPATH=FALSE \
+                            -DCMAKE_INSTALL_RPATH='\\\\\\\$ORIGIN/../lib' \
+                            -DCMAKE_BUILD_WITH_INSTALL_RPATH=TRUE \
+                            -DREQUIRE_GTEST=ON
+                    """
+        sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${configure_script}\""
+    } catch (e) {
+        failure_function(e, "CMake step for (${container_name(image_key)}) failed")
+    }
+}
+
 def docker_build(image_key) {
     try {
         def custom_sh = images[image_key]['sh']
@@ -118,13 +142,13 @@ def docker_build(image_key) {
     }
 }
 
-def docker_test(image_key) {
+def docker_test(image_key, test_dir) {
     try {
         def custom_sh = images[image_key]['sh']
         def test_script = """
                         cd build
                         . ./activate_run.sh
-                        ./tests/tests
+                        ./${test_dir}/tests
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${test_script}\""
     } catch (e) {
@@ -150,9 +174,15 @@ def docker_formatting(image_key) {
 def docker_archive(image_key) {
     try {
         def custom_sh = images[image_key]['sh']
-        def archive_output = "forward-epics-to-kafka.tar.gz"
+        def archive_output = "${project}-${image_key}.tar.gz"
         def archive_script = """
-                    tar czf ${archive_output} build
+                    cd build
+                    rm -rf forward-epics-to-kafka; mkdir forward-epics-to-kafka
+                    mkdir forward-epics-to-kafka/bin
+                    cp ./bin/forward-epics-to-kafka forward-epics-to-kafka/bin/
+                    cp -r ./lib forward-epics-to-kafka/
+                    cp -r ./licenses forward-epics-to-kafka/
+                    tar czf ${archive_output} forward-epics-to-kafka
                 """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${archive_script}\""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/${archive_output} ./"
@@ -217,7 +247,13 @@ def get_pipeline(image_key) {
 
                 docker_copy_code(image_key)
                 docker_dependencies(image_key)
-                docker_cmake(image_key)
+
+                if (image_key != release_os) {
+                    docker_cmake(image_key)
+                }
+                else {
+                    docker_cmake_release(image_key)
+                }
 
                 if (image_key == clangformat_os) {
                     docker_formatting(image_key)
@@ -228,12 +264,15 @@ def get_pipeline(image_key) {
                     if (image_key == test_and_coverage_os) {
                         docker_coverage(image_key)
                     }
+                    else if (image_key == release_os) {
+                        docker_test(image_key, "bin")
+                    }
                     else {
-                        docker_test(image_key)
+                        docker_test(image_key, "tests")
                     }
                 }
 
-                if (image_key == archive_os) {
+                if (image_key == release_os) {
                     docker_archive(image_key)
                 }
 

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -1,11 +1,11 @@
 [requires]
 gtest/3121b20-dm2@ess-dmsc/stable
 fmt/3.0.2-dm1@ess-dmsc/stable
-FlatBuffers/1.8.0@ess-dmsc/stable
-librdkafka/0.11.3-dm3@ess-dmsc/testing
-graylog-logger/1.0.3-dm1@ess-dmsc/stable
+FlatBuffers/1.9.0@ess-dmsc/stable
+librdkafka/0.11.4@ess-dmsc/stable
+graylog-logger/1.0.5-dm1@ess-dmsc/stable
 epics/3.16.1-4.6.0-dm4@ess-dmsc/stable
-streaming-data-types/3e85b23@ess-dmsc/stable
+streaming-data-types/d429d55@ess-dmsc/stable
 cli11/1.5.3@bincrafters/stable
 jsonformoderncpp/3.1.0@vthiery/stable
 
@@ -18,3 +18,8 @@ FlatBuffers:shared=True
 gtest:shared=True
 librdkafka:shared=True
 
+[imports]
+lib, *.dylib* -> ./lib
+lib, *.so* -> ./lib
+lib64, *.so* -> ./lib
+., LICENSE* -> ./licenses @ folder=True, ignore_case=True

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -11,6 +11,7 @@ jsonformoderncpp/3.1.0@vthiery/stable
 
 [generators]
 cmake
+virtualbuildenv
 virtualrunenv
 
 [options]

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -11,7 +11,6 @@ jsonformoderncpp/3.1.0@vthiery/stable
 
 [generators]
 cmake
-virtualbuildenv
 virtualrunenv
 
 [options]


### PR DESCRIPTION
### Description of work

Update release artefact archiving for integration test deployment. This incorporates changes that existed in the _essiip-deployment_ branch, which was very outdated. Conan package versions have been updated and some container settings added to the Jenkinsfile (setting CPU and memory usage). The main CMakeLists.txt file has been modified to call `conan_cmake_run` without `NO_OUTPUT_DIRS` when building in release mode.

### Issue

Closes DM-936.

### Acceptance Criteria

The Jenkins build should complete, creating a .tar.gz archive with a release build of the forwarder, including all dependencies. The previously existing debug mode builds should not be changed, besides now using more recent versions of the Conan packages..

### Unit Tests

No tests have been modified.

### Other

There was an issue with the test coverage commands hanging in many of the builds. It seemed to be related to running `make coverage` and/or `lcov` after sourcing _activate_run.sh_.

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).