### PR TITLE
Adding intelligent rebuild with docker in the system tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,13 @@ ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu17.10-build-node/ma
 
 RUN mkdir forwarder
 RUN cd forwarder
-ADD . ../forwarder_src
+
+
+ADD src/ ../forwarder_src/src
+ADD conan/ ../forwarder_src/conan/
+ADD cmake/ ../forwarder_src/cmake/
+ADD CMakeLists.txt ../forwarder_src
+ADD Doxygen.conf ../forwarder_src
 
 RUN cd forwarder && \
     cmake ../forwarder_src && \

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -52,7 +52,15 @@ common_options = {"--no-deps": False,
 
 def build_forwarder_image():
     client = docker.from_env()
-    print(client.images.build("../", quiet=False))
+    print("Building Forwarder image")
+    client.images.build(path="../", tag="forwarder:latest", rm=False)
+
+
+def run_containers(cmd, options):
+    print("Running docker-compose up", flush=True)
+    cmd.up(options)
+    print("\nFinished docker-compose up\n", flush=True)
+    wait_until_kafka_ready(cmd, options)
 
 
 @pytest.fixture(scope="module")
@@ -62,18 +70,14 @@ def docker_compose(request):
     """
     print("Started preparing test environment...", flush=True)
 
-    build_forwarder_image()
-
     # Options must be given as long form
     options = common_options
     options["--file"] = ["docker-compose.yml"]
 
+    build_forwarder_image()
     project = project_from_options(os.path.dirname(__file__), options)
     cmd = TopLevelCommand(project)
-    print("Running docker-compose up", flush=True)
-    cmd.up(options)
-    print("\nFinished docker-compose up\n", flush=True)
-    wait_until_kafka_ready(cmd, options)
+    run_containers(cmd, options)
 
     def fin():
         cmd.logs(options)
@@ -92,18 +96,14 @@ def docker_compose_fake_epics(request):
     """
     print("Started preparing test environment...", flush=True)
 
-    build_forwarder_image()
-
     # Options must be given as long form
     options = common_options
     options["--file"] = ["docker-compose-fake-epics.yml"]
 
+    build_forwarder_image()
     project = project_from_options(os.path.dirname(__file__), options)
     cmd = TopLevelCommand(project)
-    print("Running docker-compose up", flush=True)
-    cmd.up(options)
-    print("\nFinished docker-compose up\n", flush=True)
-    wait_until_kafka_ready(cmd, options)
+    run_containers(cmd, options)
 
     def fin():
         cmd.logs(options)
@@ -122,18 +122,14 @@ def docker_compose_idle_updates(request):
     """
     print("Started preparing test environment...", flush=True)
 
-    build_forwarder_image()
-
     # Options must be given as long form
     options = common_options
     options["--file"] = ["docker-compose-idle-updates.yml"]
 
+    build_forwarder_image()
     project = project_from_options(os.path.dirname(__file__), options)
     cmd = TopLevelCommand(project)
-    print("Running docker-compose up", flush=True)
-    cmd.up(options)
-    print("\nFinished docker-compose up\n", flush=True)
-    wait_until_kafka_ready(cmd, options)
+    run_containers(cmd, options)
 
     def fin():
         cmd.logs(options)
@@ -152,18 +148,14 @@ def docker_compose_idle_updates_long_period(request):
     """
     print("Started preparing test environment...", flush=True)
 
-    build_forwarder_image()
-
     # Options must be given as long form
     options = common_options
     options["--file"] = ["docker-compose-idle-updates-long-period.yml"]
 
+    build_forwarder_image()
     project = project_from_options(os.path.dirname(__file__), options)
     cmd = TopLevelCommand(project)
-    print("Running docker-compose up", flush=True)
-    cmd.up(options)
-    print("\nFinished docker-compose up\n", flush=True)
-    wait_until_kafka_ready(cmd, options)
+    run_containers(cmd, options)
 
     def fin():
         cmd.logs(options)

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -2,6 +2,7 @@ import os.path
 import pytest
 from compose.cli.main import TopLevelCommand, project_from_options
 from confluent_kafka import Producer
+import docker
 
 
 def wait_until_kafka_ready(docker_cmd, docker_options):
@@ -44,8 +45,14 @@ common_options = {"--no-deps": False,
                   "--follow": False,
                   "--timestamps": False,
                   "--tail": "all",
-                  "--detach": True
+                  "--detach": True,
+                  "--build": False
                   }
+
+
+def build_forwarder_image():
+    client = docker.from_env()
+    print(client.images.build("../", quiet=False))
 
 
 @pytest.fixture(scope="module")
@@ -54,11 +61,11 @@ def docker_compose(request):
     :type request: _pytest.python.FixtureRequest
     """
     print("Started preparing test environment...", flush=True)
-    build = False
+
+    build_forwarder_image()
 
     # Options must be given as long form
     options = common_options
-    options["--build"] = build
     options["--file"] = ["docker-compose.yml"]
 
     project = project_from_options(os.path.dirname(__file__), options)
@@ -84,11 +91,11 @@ def docker_compose_fake_epics(request):
     :type request: _pytest.python.FixtureRequest
     """
     print("Started preparing test environment...", flush=True)
-    build = False
+
+    build_forwarder_image()
 
     # Options must be given as long form
     options = common_options
-    options["--build"] = build
     options["--file"] = ["docker-compose-fake-epics.yml"]
 
     project = project_from_options(os.path.dirname(__file__), options)
@@ -114,11 +121,11 @@ def docker_compose_idle_updates(request):
     :type request: _pytest.python.FixtureRequest
     """
     print("Started preparing test environment...", flush=True)
-    build = False
+
+    build_forwarder_image()
 
     # Options must be given as long form
     options = common_options
-    options["--build"] = build
     options["--file"] = ["docker-compose-idle-updates.yml"]
 
     project = project_from_options(os.path.dirname(__file__), options)
@@ -144,11 +151,11 @@ def docker_compose_idle_updates_long_period(request):
     :type request: _pytest.python.FixtureRequest
     """
     print("Started preparing test environment...", flush=True)
-    build = False
+
+    build_forwarder_image()
 
     # Options must be given as long form
     options = common_options
-    options["--build"] = build
     options["--file"] = ["docker-compose-idle-updates-long-period.yml"]
 
     project = project_from_options(os.path.dirname(__file__), options)

--- a/system-tests/docker-compose-fake-epics.yml
+++ b/system-tests/docker-compose-fake-epics.yml
@@ -22,7 +22,7 @@ services:
     image: zookeeper:3.4
 
   forwarder:
-    build: ../
+    image: forwarder:latest
     depends_on:
       - kafka
     network_mode: "host"

--- a/system-tests/docker-compose-idle-updates-long-period.yml
+++ b/system-tests/docker-compose-idle-updates-long-period.yml
@@ -31,7 +31,7 @@ services:
           - kafka
 
   forwarder:
-    build: ../
+    image: forwarder:latest
     depends_on:
       - kafka
       - ioc

--- a/system-tests/docker-compose-idle-updates.yml
+++ b/system-tests/docker-compose-idle-updates.yml
@@ -31,7 +31,7 @@ services:
           - kafka
 
   forwarder:
-    build: ../
+    image: forwarder:latest
     depends_on:
       - kafka
       - ioc

--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - kafka
 
   forwarder:
-    build: ../
+    image: forwarder:latest
     depends_on:
       - kafka
       - ioc

--- a/system-tests/requirements.txt
+++ b/system-tests/requirements.txt
@@ -2,4 +2,5 @@ pytest>=3.4.2
 docker-compose>=1.20.0
 confluent-kafka>=0.11.4
 pyepics>=3.3.1
-flatbuffers>=2015.12.22.1
+flatbuffers>=1.9
+docker>=3.4.1


### PR DESCRIPTION
### Description of work

So the docker image does not have to built manually before running system tests. It should check whether parts of the image are out of date and rebuild just those steps rather than building all of the other images with it. 

This also means we can run the system tests in Jenkins easily (issue #74 )

### Issue

Closes #87 

### Acceptance Criteria

System tests pass 
Image is only rebuilt once if it doesn't exist beforehand then used for the rest of the test fixtures.


---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
