### PR TITLE
Populate timestamp fields in PVStructures from EpicsClientRandom

### DIFF
--- a/src/EpicsClient/EpicsClientRandom.cpp
+++ b/src/EpicsClient/EpicsClientRandom.cpp
@@ -44,7 +44,7 @@ EpicsClientRandom::createFakePVStructure(double Value) const {
   auto currentTimestamp = getCurrentTimestamp();
   auto currentTimestampSeconds = currentTimestamp / 1000000000L;
   auto currentTimestampNanosecondsComponent =
-      currentTimestamp - currentTimestampSeconds;
+      currentTimestamp - (currentTimestampSeconds * 1000000000L);
   auto Timestamp =
       FakePVStructure->getSubField<epics::pvData::PVStructure>("timeStamp");
   auto TimestampSeconds =

--- a/src/EpicsClient/EpicsClientRandom.cpp
+++ b/src/EpicsClient/EpicsClientRandom.cpp
@@ -26,12 +26,37 @@ EpicsClientRandom::createFakePVStructure(double Value) const {
   auto FieldCreator = epics::pvData::getFieldCreate();
   auto PVDataCreator = epics::pvData::getPVDataCreate();
   auto PVFieldBuilder = FieldCreator->createFieldBuilder();
-  auto Structure =
-      PVFieldBuilder->add("value", epics::pvData::pvDouble)->createStructure();
+  auto PVTimestampFieldBuilder = FieldCreator->createFieldBuilder();
+
+  PVTimestampFieldBuilder->add("secondsPastEpoch", epics::pvData::pvLong);
+  PVTimestampFieldBuilder->add("nanoseconds", epics::pvData::pvInt);
+  auto TimestampStructure = PVTimestampFieldBuilder->createStructure();
+
+  PVFieldBuilder->add("value", epics::pvData::pvDouble);
+  PVFieldBuilder->add("timeStamp", TimestampStructure);
+  auto Structure = PVFieldBuilder->createStructure();
   auto FakePVStructure = PVDataCreator->createPVStructure(Structure);
   epics::pvData::PVDoublePtr FakePVDouble =
       FakePVStructure->getSubField<epics::pvData::PVDouble>("value");
   FakePVDouble->put(Value);
+
+  // Populate timestamp
+  auto currentTimestamp = getCurrentTimestamp();
+  auto currentTimestampSeconds = currentTimestamp / 1000000000L;
+  auto currentTimestampNanosecondsComponent =
+      currentTimestamp - currentTimestampSeconds;
+  auto Timestamp =
+      FakePVStructure->getSubField<epics::pvData::PVStructure>("timeStamp");
+  auto TimestampSeconds =
+      Timestamp->getSubField<epics::pvData::PVScalarValue<int64_t>>(
+          "secondsPastEpoch");
+  TimestampSeconds->put(static_cast<int64_t>(currentTimestampSeconds));
+  auto TimestampNanoseconds =
+      Timestamp->getSubField<epics::pvData::PVScalarValue<int32_t>>(
+          "nanoseconds");
+  TimestampNanoseconds->put(
+      static_cast<int32_t>(currentTimestampNanosecondsComponent));
+
   return FakePVStructure;
 }
 

--- a/src/tests/EpicsClientRandom_tests.cpp
+++ b/src/tests/EpicsClientRandom_tests.cpp
@@ -58,3 +58,42 @@ TEST(EpicsClientRandomTest,
   // we get are different
   ASSERT_GT(abs(FirstGeneratedPVValue - SecondGeneratedPVValue), 0.00001);
 }
+
+TEST(EpicsClientRandomTest,
+     generated_pv_updates_have_populated_and_nonzero_timestamp_fields) {
+  // GIVEN an EpicsClient with a ring buffer
+  auto RingBuffer = std::make_shared<
+      moodycamel::ConcurrentQueue<std::shared_ptr<FlatBufs::EpicsPVUpdate>>>();
+  ChannelInfo ChannelInformation{"", ""};
+  auto EpicsClient =
+      EpicsClient::EpicsClientRandom(ChannelInformation, RingBuffer);
+
+  // WHEN we call generateFakePVUpdate
+  EpicsClient.generateFakePVUpdate();
+  EpicsClient.generateFakePVUpdate();
+
+  // THEN there will be an EpicsPVUpdates in the ring buffer with timestamp
+  // fields
+  std::shared_ptr<FlatBufs::EpicsPVUpdate> FirstPV;
+  ASSERT_TRUE(RingBuffer->try_dequeue(FirstPV));
+
+  auto PvTimeStamp =
+      FirstPV->epics_pvstr->getSubField<epics::pvData::PVStructure>(
+          "timeStamp");
+  // Expect timestamp field to be populated
+  ASSERT_NE(PvTimeStamp, nullptr);
+
+  // Expect more than zero seconds after the epoch
+  ASSERT_GT(PvTimeStamp
+                ->getSubField<epics::pvData::PVScalarValue<int64_t>>(
+                    "secondsPastEpoch")
+                ->get(),
+            0);
+
+  // Expect a 0 or positive number of nanoseconds in the timestamp
+  ASSERT_GT(
+      PvTimeStamp
+          ->getSubField<epics::pvData::PVScalarValue<int32_t>>("nanoseconds")
+          ->get(),
+      -1);
+}

--- a/src/tests/EpicsClientRandom_tests.cpp
+++ b/src/tests/EpicsClientRandom_tests.cpp
@@ -70,7 +70,6 @@ TEST(EpicsClientRandomTest,
 
   // WHEN we call generateFakePVUpdate
   EpicsClient.generateFakePVUpdate();
-  EpicsClient.generateFakePVUpdate();
 
   // THEN there will be an EpicsPVUpdates in the ring buffer with timestamp
   // fields


### PR DESCRIPTION
### Description of work

Populate timestamp fields in PVStructures from EpicsClientRandom so that the resultant messages in Kafka have suitable timestamps set for the File Writer to record and compare against its start time.

### Issue

Closes #154

### Acceptance Criteria

Could test against the File Writer using https://github.com/ess-dmsc/mohican-yak
Just temporarily remove the Forwarder from the docker-compose and run it manually.

### Unit Tests

New unit test in `EpicsClientRandom_tests.cpp` to check that the timestamp fields are populated.

---

## Code Review (To be filled in by the reviewer only)

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
