### PR TITLE
Replacing pyepics with docker call through IOC container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && \
-    apt-get --no-install-recommends -y install cmake g++ git python-pip tzdata vim-common && \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y && \
+    apt-get --no-install-recommends -y install make cmake g++ git python-pip tzdata vim-common && \
     apt-get -y autoremove && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip==9.0.3 && \
+RUN pip install --upgrade pip==9.0.3 && pip install setuptools && \
     pip install conan && \
     rm -rf /root/.cache/pip/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,24 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 RUN apt-get update && \
-    apt-get -y install cmake g++ git python-pip tzdata vim-common && \
+    apt-get --no-install-recommends -y install cmake g++ git python-pip tzdata vim-common && \
     apt-get -y autoremove && \
-    apt-get clean all
+    apt-get clean all && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip==9.0.3 && \
-    pip install conan==1.0.2 && \
+    pip install conan && \
     rm -rf /root/.cache/pip/*
 
 # Force conan to create .conan directory and profile
 RUN conan profile new default
 
-# Replace the default profile and remotes with the ones from our Ubuntu 17.10 build node
-ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu17.10-build-node/master/files/registry.txt" "/root/.conan/registry.txt"
-ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu17.10-build-node/master/files/default_profile" "/root/.conan/profiles/default"
+# Replace the default profile and remotes with the ones from our Ubuntu build node
+ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/registry.txt" "/root/.conan/registry.txt"
+ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/default_profile" "/root/.conan/profiles/default"
 
 RUN mkdir forwarder
 RUN cd forwarder
-
 
 ADD src/ ../forwarder_src/src
 ADD conan/ ../forwarder_src/conan/

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -52,7 +52,7 @@ common_options = {"--no-deps": False,
 
 def build_forwarder_image():
     client = docker.from_env()
-    print("Building Forwarder image")
+    print("Building Forwarder image", flush=True)
     client.images.build(path="../", tag="forwarder:latest", rm=False)
 
 

--- a/system-tests/helpers/epics_helpers.py
+++ b/system-tests/helpers/epics_helpers.py
@@ -1,4 +1,4 @@
-from epics import caput
+import docker
 
 
 def change_pv_value(pvname, value):
@@ -9,4 +9,6 @@ def change_pv_value(pvname, value):
     :param value: PV value to change to
     :return: none
     """
-    caput(pvname, value, wait=True)
+    client = docker.from_env()
+    container = client.containers.get("forwarder_ioc_1")
+    container.exec_run("caput {} {}".format(pvname, value), privileged=True)

--- a/system-tests/helpers/epics_helpers.py
+++ b/system-tests/helpers/epics_helpers.py
@@ -10,5 +10,8 @@ def change_pv_value(pvname, value):
     :return: none
     """
     client = docker.from_env()
-    container = client.containers.get("forwarder_ioc_1")
+    for item in client.containers.list():
+        if "_ioc_1" in item.name:
+            container = item
+            break
     container.exec_run("caput {} {}".format(pvname, value), privileged=True)

--- a/system-tests/helpers/epics_helpers.py
+++ b/system-tests/helpers/epics_helpers.py
@@ -9,9 +9,12 @@ def change_pv_value(pvname, value):
     :param value: PV value to change to
     :return: none
     """
+    container = False
     client = docker.from_env()
     for item in client.containers.list():
         if "_ioc_1" in item.name:
             container = item
             break
+    if not container:
+        raise Exception("IOC Container not found")
     container.exec_run("caput {} {}".format(pvname, value), privileged=True)

--- a/system-tests/requirements.txt
+++ b/system-tests/requirements.txt
@@ -1,6 +1,5 @@
 pytest>=3.4.2
 docker-compose>=1.20.0
 confluent-kafka>=0.11.4
-pyepics>=3.3.1
 flatbuffers>=1.9
 docker>=3.4.1

--- a/system-tests/test_forwarding.py
+++ b/system-tests/test_forwarding.py
@@ -104,6 +104,7 @@ def test_forwarder_sends_pv_updates_single_pv_string(docker_compose):
 
     check_expected_values(data_msg, Value.String, PVSTR, b'stop')
 
+    # We have to use this as the second parameter for caput gets parsed as empty so does not change the value of the PV
     change_pv_value(PVSTR, "\"\"")
     prod.stop_all()
     sleep(3)

--- a/system-tests/test_forwarding.py
+++ b/system-tests/test_forwarding.py
@@ -91,8 +91,7 @@ def test_forwarder_sends_pv_updates_single_pv_string(docker_compose):
 
     cons = create_consumer()
     # Update value
-    stop_command = b'stop'
-    change_pv_value(PVSTR, stop_command)
+    change_pv_value(PVSTR, "stop")
 
     # Wait for PV to be updated
     sleep(5)
@@ -103,9 +102,9 @@ def test_forwarder_sends_pv_updates_single_pv_string(docker_compose):
     # Poll for message which should contain forwarded PV update
     data_msg = poll_for_valid_message(cons)
 
-    check_expected_values(data_msg, Value.String, PVSTR, stop_command)
+    check_expected_values(data_msg, Value.String, PVSTR, b'stop')
 
-    change_pv_value(PVSTR, "")
+    change_pv_value(PVSTR, "\"\"")
     prod.stop_all()
     sleep(3)
     cons.close()


### PR DESCRIPTION
### Description of work

Removes the dependency for EPICS to be on the system running the tests and uses a docker call instead of an EPICS library call.

### Issue

Closes #141 

### Acceptance Criteria

Run system tests and check they all pass still. 

### Other

Updated `requirements.txt` 

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
