### PR TITLE
Added missing virtual destructors

### DIFF
--- a/src/SchemaRegistry.h
+++ b/src/SchemaRegistry.h
@@ -11,6 +11,7 @@ class SchemaInfo {
 public:
   typedef std::unique_ptr<SchemaInfo> ptr;
   virtual std::unique_ptr<FlatBufferCreator> create_converter() = 0;
+  virtual ~SchemaInfo() = default;
 };
 
 class SchemaRegistry {

--- a/src/Stream.h
+++ b/src/Stream.h
@@ -30,7 +30,7 @@ class ConversionPath {
 public:
   ConversionPath(ConversionPath &&x) noexcept;
   ConversionPath(std::shared_ptr<Converter>, std::unique_ptr<KafkaOutput>);
-  ~ConversionPath();
+  virtual ~ConversionPath();
   int emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> up);
   std::atomic<uint32_t> transit{0};
   nlohmann::json status_json() const;

--- a/src/Timer.h
+++ b/src/Timer.h
@@ -15,6 +15,7 @@ namespace Forwarder {
 class Sleeper {
 public:
   virtual void sleepFor(std::chrono::milliseconds Duration) = 0;
+  virtual ~Sleeper() = default;
 };
 
 /// Wraps this_thread::sleep_for.


### PR DESCRIPTION
### Description of work
By accident (don't ask) I built the forwarder with a newer version of clang and it gave a few warnings relating to missing virtual destructors.

To me these warnings seem valid as the classes (or their children) identified usually end up in some kind of pointer.

### Issue

N/A

### Acceptance Criteria
The changes are sensible.

### Unit Tests

N/A

### Other

N/A

---

## Code Review (To be filled in by the reviewer only)

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
