### PR TITLE
Replace Range with std::pair

### DIFF
--- a/src/RangeSet.h
+++ b/src/RangeSet.h
@@ -6,76 +6,8 @@
 #include <mutex>
 #include <set>
 
-/// Represents an inclusive range.
-template <typename T> class Range {
-public:
-  Range(T a, T b) : a(a), b(b) {}
-  T a;
-  T b;
-  bool check_consistent() {
-    if (a > b) {
-      throw std::runtime_error("not consistent");
-    }
-  }
-  std::string to_s() const { return fmt::format("<Range {:3} {:3}>", a, b); }
-};
-
-template <typename T>
-constexpr bool operator<(Range<T> const &a, Range<T> const &b) {
-  return (a.a < b.a || (a.a == b.a && a.b < b.b));
-}
-
-/// Test if the given ranges form together a gapless range.
-template <typename T> bool is_gapless(Range<T> const &a, Range<T> const &b) {
-  if (!(a < b)) {
-    throw std::runtime_error("expect a < b");
-  }
-  if (a.b + 1 >= b.a) {
-    return true;
-  }
-  return false;
-}
-
-/// Merge the given ranges into a new range.
-template <typename T> Range<T> merge(Range<T> const &a, Range<T> const &b) {
-  if (!(a < b)) {
-    throw std::runtime_error("expect a < b");
-  }
-  return Range<T>(a.a, std::max(a.b, b.b));
-}
-
-template <typename T> inline void minmax(T *mm, T const &x) {
-  T &min = mm[0];
-  T &max = mm[1];
-  if (min == -1 || x < min) {
-    min = x;
-  }
-  if (max == -1 || x > max) {
-    max = x;
-  }
-}
-
 /// A set of continuous inclusive ranges.
-template <typename T> class RangeSet {
-public:
-  void insert(T k) {
-    std::unique_lock<std::mutex> lock(Mutex);
-    set.emplace(k, k);
-    while (true) {
-      auto a1 = std::adjacent_find(set.begin(), set.end(), is_gapless<T>);
-      if (a1 == set.end()) {
-        break;
-      } else {
-        auto a2 = a1;
-        ++a2;
-        auto a3 = merge(*a1, *a2);
-        set.erase(a1);
-        set.erase(a2);
-        set.insert(a3);
-      }
-    }
-  }
-
+template <typename T> struct RangeSet {
   size_t size() {
     std::unique_lock<std::mutex> lock(Mutex);
     return set.size();
@@ -90,7 +22,7 @@ public:
       if (i1 > 0) {
         mw.write(", ");
       }
-      mw.write("[{}, {}]", x.a, x.b);
+      mw.write("[{}, {}]", x.first, x.second);
       ++i1;
       if (i1 > 100) {
         mw.write(" ...");
@@ -101,6 +33,6 @@ public:
     return std::string(mw.c_str());
   }
 
-  std::set<Range<T>> set;
+  std::set<std::pair<T, T>> set;
   std::mutex Mutex;
 };

--- a/src/Stream.cpp
+++ b/src/Stream.cpp
@@ -160,7 +160,7 @@ nlohmann::json Stream::getStatusJson() {
     auto const &Set = SeqDataEmitted.set;
     auto Last = Set.rbegin();
     if (Last != Set.rend()) {
-      Document["emitted_max"] = Last->b;
+      Document["emitted_max"] = Last->second;
     }
   }
   auto Converters = json::array();


### PR DESCRIPTION
### Description of work

Replacing `Range` in `RangeSet.h` with a std::pair which has the same comparison abilities to my knowledge. 

The functions in this class didn't seem to be used.  

### Issue

Closes #218 

### Acceptance Criteria

`Stream.h` has been modified as well as `Rangeset.h` 

System tests should pass 

Unit tests should pass 

### Unit Tests

None modified. 

### Other

None. 

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
