### PR TITLE
229 delete callback interface

### DIFF
--- a/src/CommandHandler.h
+++ b/src/CommandHandler.h
@@ -1,12 +1,13 @@
 #pragma once
 #include "Config.h"
 #include "Forwarder.h"
+#include "nlohmann/json.hpp"
 #include <string>
-
 namespace Forwarder {
+class Forwarder;
 
 /// Helper class to provide a callback for the Kafka command listener.
-class ConfigCB : public Config::Callback {
+class ConfigCB {
 public:
   /// Constructor.
   ///
@@ -16,7 +17,7 @@ public:
   /// The callback entry-point.
   ///
   /// \param msg The message to handle.
-  void operator()(std::string const &msg) override;
+  void operator()(std::string const &msg);
 
   /// Extract the command type from the message.
   ///

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -42,10 +42,5 @@ void Listener::poll(::Forwarder::ConfigCB &cb) {
     cb({(char *)Message->getData(), Message->getSize()});
   }
 }
-
-void Listener::wait_for_connected(std::chrono::milliseconds timeout) {
-  std::unique_lock<std::mutex> lock(impl->mx);
-  impl->cv.wait_for(lock, timeout, [this] { return impl->connected == 1; });
-}
 } // namespace Config
 } // namespace Forwarder

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -14,7 +14,7 @@ struct Listener_impl {
   int connected = 0;
 };
 
-Listener::Listener(KafkaW::BrokerSettings BrokerSettings, Forwarder::URI uri) {
+Listener::Listener(KafkaW::BrokerSettings BrokerSettings, URI uri) {
   BrokerSettings.Address = uri.host_port;
   BrokerSettings.PollTimeoutMS = 0;
   impl.reset(new Listener_impl);
@@ -36,7 +36,7 @@ Listener::Listener(KafkaW::BrokerSettings BrokerSettings, Forwarder::URI uri) {
 
 Listener::~Listener() {}
 
-void Listener::poll(Callback &cb) {
+void Listener::poll(::Forwarder::ConfigCB &cb) {
   auto Message = impl->consumer->poll();
   if (Message->getStatus() == KafkaW::PollStatus::Msg) {
     cb({(char *)Message->getData(), Message->getSize()});

--- a/src/Config.h
+++ b/src/Config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "CommandHandler.h"
 #include "KafkaW/KafkaW.h"
 #include "uri.h"
 #include <atomic>
@@ -9,18 +10,12 @@
 #include <vector>
 
 namespace Forwarder {
-
+class ConfigCB;
 class Remote_T;
 
 namespace Config {
 
 using std::string;
-
-/// Interface to react on configuration messages.
-class Callback {
-public:
-  virtual void operator()(string const &msg) = 0;
-};
 
 struct Listener_impl;
 
@@ -29,7 +24,7 @@ public:
   Listener(KafkaW::BrokerSettings bopt, URI uri);
   Listener(Listener const &) = delete;
   ~Listener();
-  void poll(Callback &cb);
+  void poll(::Forwarder::ConfigCB &cb);
   void wait_for_connected(std::chrono::milliseconds timeout);
 
 private:

--- a/src/Config.h
+++ b/src/Config.h
@@ -11,7 +11,6 @@
 
 namespace Forwarder {
 class ConfigCB;
-class Remote_T;
 
 namespace Config {
 
@@ -25,11 +24,9 @@ public:
   Listener(Listener const &) = delete;
   ~Listener();
   void poll(::Forwarder::ConfigCB &cb);
-  void wait_for_connected(std::chrono::milliseconds timeout);
 
 private:
   std::unique_ptr<Listener_impl> impl;
-  friend class Remote_T;
 };
 } // namespace Config
 } // namespace Forwarder

--- a/src/Forwarder.h
+++ b/src/Forwarder.h
@@ -21,9 +21,6 @@ public:
 class Converter;
 class Stream;
 class Timer;
-namespace tests {
-class Remote_T;
-}
 
 namespace Config {
 class Listener;
@@ -78,7 +75,7 @@ private:
   std::vector<std::unique_ptr<ConversionWorker>> conversion_workers;
   ConversionScheduler conversion_scheduler;
   friend class ConfigCB;
-  friend class tests::Remote_T;
+//  friend class tests::Remote_T;
   friend class ConversionScheduler;
   std::atomic<ForwardingStatus> forwarding_status{ForwardingStatus::NORMAL};
   std::unique_ptr<CURLReporter> curl;

--- a/src/Forwarder.h
+++ b/src/Forwarder.h
@@ -74,8 +74,6 @@ private:
   std::mutex conversion_workers_mx;
   std::vector<std::unique_ptr<ConversionWorker>> conversion_workers;
   ConversionScheduler conversion_scheduler;
-  friend class ConfigCB;
-  friend class ConversionScheduler;
   std::atomic<ForwardingStatus> forwarding_status{ForwardingStatus::NORMAL};
   std::unique_ptr<CURLReporter> curl;
   std::shared_ptr<KafkaW::Producer> status_producer;

--- a/src/Forwarder.h
+++ b/src/Forwarder.h
@@ -75,7 +75,6 @@ private:
   std::vector<std::unique_ptr<ConversionWorker>> conversion_workers;
   ConversionScheduler conversion_scheduler;
   friend class ConfigCB;
-//  friend class tests::Remote_T;
   friend class ConversionScheduler;
   std::atomic<ForwardingStatus> forwarding_status{ForwardingStatus::NORMAL};
   std::unique_ptr<CURLReporter> curl;


### PR DESCRIPTION
### Description of work

Deleted callback interface from Config.h/cpp. I believe it was once used for some mocks, now it was unused.
Similarly removed unused variable and method from Listener.

### Issue

Closes #229 

### Acceptance Criteria

Commandhandler.h
Config.h/cpp
Forwarder.h

### Unit Tests

n/a

### Other

n/a

---

## Code Review (To be filled in by the reviewer only)

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
