### PR TITLE
re DM-1244 Adding forwarder container output to jenkins

### DIFF
--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -79,6 +79,9 @@ def build_and_run(options, request):
     def fin():
         # Stop the containers then remove them and their volumes (--volumes option)
         print("containers stopping", flush=True)
+        log_options = dict(options)
+        log_options["SERVICE"] = ["forwarder"]
+        cmd.logs(log_options)
         options["--timeout"] = 30
         cmd.down(options)
         print("containers stopped", flush=True)


### PR DESCRIPTION
### Description of work

Adding the forwarder container output to jenkins if the program terminates. Previously this was uncaught as it would stop logging to a file (done through the command line args) 

### Issue

Closes DM-1244

### Acceptance Criteria

To test: 

Comment out `log-file` in one of the system test INI files and check the container outputs all logs to stdout 

### Unit Tests

None

### Other

None

---

## Code Review (To be filled in by the reviewer only)

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
