### PR TITLE
Add local conan server in system tests Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN conan profile new default
 ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/registry.json" "/root/.conan/registry.json"
 ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/default_profile" "/root/.conan/profiles/default"
 
+# Add local Conan server
+RUN conan remote add --insert 0 ess-dmsc-local http://eeenfs.dm.esss.dk:9300
+
 RUN mkdir forwarder
 
 COPY conan/ ../forwarder_src/conan/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ARG http_proxy
 
 ARG https_proxy
 
+ARG local_conan_server
+
 RUN apt-get update -y && \
     apt-get --no-install-recommends -y install build-essential git python-pip cmake tzdata vim  && \
     apt-get -y autoremove && \
@@ -24,7 +26,7 @@ ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/ma
 ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/default_profile" "/root/.conan/profiles/default"
 
 # Add local Conan server
-RUN conan remote add --insert 0 ess-dmsc-local http://eeenfs.dm.esss.dk:9300
+RUN if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi
 
 RUN mkdir forwarder
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -380,7 +380,7 @@ def get_win10_pipeline() {
 
 def get_system_tests_pipeline() {
     return {
-        node('integration-test') {
+        node('system-test') {
             cleanWs()
             dir("${project}") {
                 try{
@@ -395,7 +395,7 @@ def get_system_tests_pipeline() {
                     stage("System tests: Run") {
                         sh """docker stop \$(docker ps -a -q) && docker rm \$(docker ps -a -q) || true
                                                 """
-			timeout(time: 30, activity: true){     
+			timeout(time: 30, activity: true){
                             sh """cd system-tests/
                             scl enable rh-python35 -- python -m pytest -s  --junitxml=./SystemTestsOutput.xml ./
                             """

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -58,6 +58,8 @@ def build_forwarder_image():
         build_args["http_proxy"] = os.environ["http_proxy"]
     if "https_proxy" in os.environ:
         build_args["https_proxy"] = os.environ["https_proxy"]
+    if "local_conan_server" in os.environ:
+        build_args["local_conan_server"] = os.environ["local_conan_server"]
     image, logs = client.images.build(path="../", tag="forwarder:latest", rm=False, buildargs=build_args)
     for item in logs:
         print(item, flush=True)


### PR DESCRIPTION
### Description of work

Make dockerised system tests use cached binary Conan packages instead of building them from source.

### Issue

Closes #DM-1267.

### Acceptance Criteria

The system tests should download binary Conan packages from the local server, instead of building them from source.

### Unit Tests

n/a

### Other

Changed system tests.

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).