### PR TITLE
Changing Consumer to assign to highest offset on partition rather than lowest. 

### DIFF
--- a/src/KafkaW/Consumer.cpp
+++ b/src/KafkaW/Consumer.cpp
@@ -87,7 +87,7 @@ void Consumer::addTopic(const std::string &Topic) {
     int64_t Low, High;
     KafkaConsumer->query_watermark_offsets(Topic, PartitionID, &Low, &High,
                                            1000);
-    TopicPartition->set_offset(Low);
+    TopicPartition->set_offset(High);
     TopicPartitionsWithOffsets.push_back(TopicPartition);
   }
   RdKafka::ErrorCode Err = KafkaConsumer->assign(TopicPartitionsWithOffsets);


### PR DESCRIPTION
### Description of work

The Forwarder was previously assigning to the highest offset on a partition, therefore meaning that if there were already commands on the topic it was assigned to for receiving command messages, it would try and add PVs that might not exist anymore. 

### Issue

DM-1322

### Acceptance Criteria

Changed set_offset call to assign from highest offset on each `RdKafka::TopicPartition.`

### Unit Tests

None modified. 

### Other

None

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
