### PR TITLE
Use PV name as message key

### DIFF
--- a/src/FlatbufferMessage.h
+++ b/src/FlatbufferMessage.h
@@ -17,7 +17,6 @@ class Converter;
 /// Holds the flatbuffer until it has been sent.
 ///
 /// Basically POD.  Holds the flatbuffer until no longer needed.
-/// Also holds some internal counters for performance testing.
 /// If you want to implement your own custom memory management, this is the
 /// class to inherit from.
 class FlatbufferMessage : public KafkaW::ProducerMessage {

--- a/src/KafkaOutput.cpp
+++ b/src/KafkaOutput.cpp
@@ -16,8 +16,8 @@ int KafkaOutput::emit(std::unique_ptr<FlatBufs::FlatbufferMessage> fb) {
     return -1024;
   }
   auto m1 = fb->message();
-  fb->data = m1.data;
-  fb->size = m1.size;
+  fb->Data = m1.data;
+  fb->Size = m1.size;
   std::unique_ptr<KafkaW::ProducerMessage> msg(fb.release());
   auto x = Output.produce(msg);
   if (x == 0) {

--- a/src/KafkaW/ProducerMessage.h
+++ b/src/KafkaW/ProducerMessage.h
@@ -5,8 +5,8 @@
 namespace KafkaW {
 struct ProducerMessage {
   virtual ~ProducerMessage() = default;
-  unsigned char *data;
-  uint32_t size;
-  std::string key; // Used by producer if not empty
+  unsigned char *Data;
+  uint32_t Size;
+  std::string Key; // Used by producer if not empty
 };
 }

--- a/src/KafkaW/ProducerMessage.h
+++ b/src/KafkaW/ProducerMessage.h
@@ -1,10 +1,12 @@
 #pragma once
 #include <stdint.h>
+#include <string>
 
 namespace KafkaW {
 struct ProducerMessage {
   virtual ~ProducerMessage() = default;
   unsigned char *data;
   uint32_t size;
+  std::string key;  // Used by producer if not empty
 };
 }

--- a/src/KafkaW/ProducerTopic.cpp
+++ b/src/KafkaW/ProducerTopic.cpp
@@ -29,8 +29,8 @@ ProducerTopic::ProducerTopic(ProducerTopic &&x) noexcept {
 struct Msg_ : public ProducerMessage {
   std::vector<unsigned char> v;
   void finalize() {
-    data = v.data();
-    size = v.size();
+    Data = v.data();
+    Size = v.size();
   }
 };
 
@@ -58,17 +58,17 @@ int ProducerTopic::produce(std::unique_ptr<ProducerMessage> &Msg) {
   int MsgFlags = 0;
   auto &ProducerStats = KafkaProducer->Stats;
 
-  if (!Msg->key.empty()) {
-    key = Msg->key.c_str();
-    key_len = Msg->key.size();
+  if (!Msg->Key.empty()) {
+    key = Msg->Key.c_str();
+    key_len = Msg->Key.size();
   }
 
   switch (KafkaProducer->produce(
-      RdKafkaTopic.get(), RdKafka::Topic::PARTITION_UA, MsgFlags, Msg->data,
-      Msg->size, key, key_len, Msg.get())) {
+      RdKafkaTopic.get(), RdKafka::Topic::PARTITION_UA, MsgFlags, Msg->Data,
+      Msg->Size, key, key_len, Msg.get())) {
   case RdKafka::ERR_NO_ERROR:
     ++ProducerStats.produced;
-    ProducerStats.produced_bytes += static_cast<uint64_t>(Msg->size);
+    ProducerStats.produced_bytes += static_cast<uint64_t>(Msg->Size);
     ++KafkaProducer->TotalMessagesProduced;
     Msg.release(); // we clean up the message after it has been sent, see
                    // comment by MsgFlags declaration
@@ -82,7 +82,7 @@ int ProducerTopic::produce(std::unique_ptr<ProducerMessage> &Msg) {
 
   case RdKafka::ERR_MSG_SIZE_TOO_LARGE:
     ++ProducerStats.msg_too_large;
-    LOG(Sev::Error, "Message size too large to publish, size: {}", Msg->size);
+    LOG(Sev::Error, "Message size too large to publish, size: {}", Msg->Size);
     break;
 
   default:

--- a/src/KafkaW/ProducerTopic.cpp
+++ b/src/KafkaW/ProducerTopic.cpp
@@ -58,6 +58,12 @@ int ProducerTopic::produce(std::unique_ptr<ProducerMessage> &Msg) {
   int MsgFlags = 0;
   auto &ProducerStats = KafkaProducer->Stats;
 
+  if (!Msg->key.empty()) {
+    LOG(Sev::Error, "Message key is {}", Msg->key)
+    key = Msg->key.c_str();
+    key_len = Msg->key.size();
+  }
+
   switch (KafkaProducer->produce(
       RdKafkaTopic.get(), RdKafka::Topic::PARTITION_UA, MsgFlags, Msg->data,
       Msg->size, key, key_len, Msg.get())) {

--- a/src/KafkaW/ProducerTopic.cpp
+++ b/src/KafkaW/ProducerTopic.cpp
@@ -59,7 +59,6 @@ int ProducerTopic::produce(std::unique_ptr<ProducerMessage> &Msg) {
   auto &ProducerStats = KafkaProducer->Stats;
 
   if (!Msg->key.empty()) {
-    LOG(Sev::Error, "Message key is {}", Msg->key)
     key = Msg->key.c_str();
     key_len = Msg->key.size();
   }

--- a/src/schemas/f142/f142.cpp
+++ b/src/schemas/f142/f142.cpp
@@ -3,7 +3,7 @@
 #include "../../SchemaRegistry.h"
 #include "../../helper.h"
 #include "../../logger.h"
-#include "schemas/f142_logdata_generated.h"
+#include <f142_logdata_generated.h>
 #include <atomic>
 #include <mutex>
 #include <pv/nt.h>
@@ -367,6 +367,10 @@ public:
     LogDataBuilder.add_source_name(PVName);
     LogDataBuilder.add_value_type(Value.Type);
     LogDataBuilder.add_value(Value.Offset);
+
+    // Use the PV name as the message key so that all messages for the same PV
+    // end up in the same Kafka partition and thus have publish order maintained
+    FlatbufferMessage->key = PVUpdate.channel;
 
     if (auto PVTimeStamp =
             PVStructure->getSubField<epics::pvData::PVStructure>("timeStamp")) {

--- a/src/schemas/f142/f142.cpp
+++ b/src/schemas/f142/f142.cpp
@@ -370,7 +370,7 @@ public:
 
     // Use the PV name as the message key so that all messages for the same PV
     // end up in the same Kafka partition and thus have publish order maintained
-    FlatbufferMessage->key = PVUpdate.channel;
+    FlatbufferMessage->Key = PVUpdate.channel;
 
     if (auto PVTimeStamp =
             PVStructure->getSubField<epics::pvData::PVStructure>("timeStamp")) {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -2,7 +2,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ../../tests)
 
 set(tgt "tests")
 set(sources
-    tests.cpp
     URI_tests.cpp
     json_tests.cpp
     ConfigParser_tests.cpp

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -1,6 +1,0 @@
-#include <gtest/gtest.h>
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/system-tests/compose/docker-compose-kafka.yml
+++ b/system-tests/compose/docker-compose-kafka.yml
@@ -15,7 +15,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_MESSAGE_MAX_BYTES: 10000000
       KAFKA_BROKER_ID: 0
-      KAFKA_CREATE_TOPICS: "TEST_forwarderConfig:1:1"
+      KAFKA_CREATE_TOPICS: "TEST_forwarderConfig:1:1,TEST_forwarderData_2_partitions:2:1"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 

--- a/system-tests/helpers/kafka_helpers.py
+++ b/system-tests/helpers/kafka_helpers.py
@@ -14,10 +14,12 @@ def get_all_available_messages(consumer):
     :return: list of messages, empty if none available
     """
     messages = []
-    while True:
-        message = consumer.poll(timeout=1.0)
-        if message is None:
-            break
+    low_offset, high_offset = consumer.get_watermark_offsets(consumer.assignment()[0], cached=False)
+    number_of_messages_available = high_offset - low_offset
+    while len(messages) < number_of_messages_available:
+        message = consumer.poll(timeout=2.0)
+        if message is None or message.error():
+            continue
         messages.append(message)
     return messages
 

--- a/system-tests/helpers/kafka_helpers.py
+++ b/system-tests/helpers/kafka_helpers.py
@@ -7,12 +7,27 @@ class MsgErrorException(Exception):
     pass
 
 
+def get_all_available_messages(consumer):
+    """
+    Consumes all available messages topics subscribed to by the consumer
+    :param consumer: The consumer object
+    :return: list of messages, empty if none available
+    """
+    messages = []
+    while True:
+        message = consumer.poll(timeout=1.0)
+        if message is None:
+            break
+        messages.append(message)
+    return messages
+
+
 def poll_for_valid_message(consumer):
     """
     Polls the subscribed topics by the consumer and checks the buffer is not empty or malformed.
 
-    :param consumer: The consumer object.
-    :return: The message object received from polling.
+    :param consumer: The consumer object
+    :return: The LogData flatbuffer from the message payload
     """
     msg = consumer.poll(timeout=1.0)
     assert msg is not None

--- a/system-tests/test_forwarding.py
+++ b/system-tests/test_forwarding.py
@@ -283,7 +283,7 @@ def test_updates_from_the_same_pv_reach_the_same_partition(docker_compose):
     consumer_partition_1 = create_consumer()
     consumer_partition_1.assign([TopicPartition(data_topic, partition=1)])
 
-    sleep(2)
+    sleep(5)
 
     # There should be 3 messages in total for each PV
     # (the initial value and these two updates)
@@ -297,17 +297,19 @@ def test_updates_from_the_same_pv_reach_the_same_partition(docker_compose):
     change_pv_value(PVLONG, 2)
     sleep(0.5)
 
-    sleep(2)
+    sleep(5)
 
     def test_all_messages_for_pv_are_in_one_partition(consumer):
         messages = get_all_available_messages(consumer)
         # if we have any messages in this partition
         if len(messages) != 0:
-            pv_name = messages[1].key()
+            pv_name = messages[0].key()
             assert pv_name is not None
-            count_of_messages_with_pv_name = sum(1 for message in messages if message.key == pv_name)
+            count_of_messages_with_pv_name = sum(1 for message in messages if message.key() == pv_name)
             # then we expect exactly 3 with the same key as the first message
             assert count_of_messages_with_pv_name == 3
+            return True
+        return False
 
-    test_all_messages_for_pv_are_in_one_partition(consumer_partition_0)
-    test_all_messages_for_pv_are_in_one_partition(consumer_partition_1)
+    assert test_all_messages_for_pv_are_in_one_partition(consumer_partition_0) or \
+           test_all_messages_for_pv_are_in_one_partition(consumer_partition_1)

--- a/system-tests/test_forwarding.py
+++ b/system-tests/test_forwarding.py
@@ -311,5 +311,6 @@ def test_updates_from_the_same_pv_reach_the_same_partition(docker_compose):
             return True
         return False
 
+    # Must find three messages with the same key in at least one of the two partitions
     assert test_all_messages_for_pv_are_in_one_partition(consumer_partition_0) or \
            test_all_messages_for_pv_are_in_one_partition(consumer_partition_1)


### PR DESCRIPTION
### Issue

DM-1283

### Description of work

Uses the PV name as the message key for PV update messages published to Kafka. This will ensure the order of published PV messages is maintained.

Added a system test to cover this behaviour: `test_forwarding.py`, `test_updates_from_the_same_pv_reach_the_same_partition`

### Nominate for Group Code Review

- [ ] Nominate for code review 
