### PR TITLE
Slimming down docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,12 @@
 .gitignore
 ansible
 /src/scripts/
+/src/tests/
+system-tests/
+*.md
+.clang-format
+.dockerignore
+codecov.yml
+Dockerfile
+Jenkinsfile
+*.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,39 @@
 FROM ubuntu:18.04
 
-ENV DEBIAN_FRONTEND=noninteractive
-
 ARG http_proxy
 
 ARG https_proxy
 
 ARG local_conan_server
 
-RUN apt-get update -y && \
-    apt-get --no-install-recommends -y install build-essential git python-pip cmake tzdata vim  && \
-    apt-get -y autoremove && \
-    apt-get clean all && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN pip install --upgrade pip==9.0.3 && pip install setuptools && \
-    pip install conan && \
-    rm -rf /root/.cache/pip/*
-
-# Force conan to create .conan directory and profile
-RUN conan profile new default
-
 # Replace the default profile and remotes with the ones from our Ubuntu build node
 ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/registry.json" "/root/.conan/registry.json"
 ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/default_profile" "/root/.conan/profiles/default"
 
-# Add local Conan server
-RUN if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi
-
-RUN mkdir forwarder
-
 COPY conan/ ../forwarder_src/conan/
-RUN cd forwarder && conan install --build=outdated ../forwarder_src/conan/conanfile.txt
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update -y \
+    && apt-get --no-install-recommends -y install build-essential git python-pip cmake tzdata vim \
+    && apt-get -y autoremove \
+    && apt-get clean all \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --upgrade pip==9.0.3 \
+    && pip install setuptools \
+    && pip install conan \
+    && rm -rf /root/.cache/pip/* \
+    && mkdir forwarder \
+    && if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi \
+    && cd forwarder \
+    && conan install --build=outdated ../forwarder_src/conan/conanfile.txt
+
 COPY cmake/ ../forwarder_src/cmake/
 COPY CMakeLists.txt ../forwarder_src
-COPY src/ ../forwarder_src/src
+COPY src/ ../forwarder_src/src/
 
 RUN cd forwarder && \
     cmake -DCONAN="MANUAL" ../forwarder_src && \
-    make -j4 forward-epics-to-kafka VERBOSE=1
+    make -j4 forward-epics-to-kafka VERBOSE=1 && apt-get remove --purge -y build-essential git python-pip cmake && rm -rf ../forwarder_src
 
 ADD docker_launch.sh /
 CMD ["./docker_launch.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && conan install --build=outdated ../forwarder_src/conan/conanfile.txt
 
 # Second copy for everything so that the cached image can be used if only the source files change.
-# The conan install step doesn't have to run again as it is after this copy.
 COPY ./ ../forwarder_src/
 
 RUN cd forwarder \


### PR DESCRIPTION
### Issue

relates to DM-1406

### Description of work

I have bundled steps into layers as more layers in the docker image means more space when building. This approach shouldn't take any longer than usual. The image will rebuild when the conanfile updates, however as this only happens every so often and it already causes the build time to increase I don't think this is an issue. 

When merged: create and push new image to docker hub 

### Nominate for Group Code Review

- [ ] Nominate for code review 
