### PR TITLE
Set build unstable if cppcheck warnings increase

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -312,7 +312,7 @@ def get_pipeline(image_key) {
                 if (image_key == clangformat_os) {
                     docker_formatting(image_key)
                     docker_cppcheck(image_key)
-		    recordIssues healthy: 2, tools: [cppCheck()], unhealthy: 2
+		    recordIssues qualityGates: [[threshold: 2, type: 'TOTAL', unstable: true]], tools: [cppCheck()]
                     //step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']], unstableTotalAll: '2'])
                 } else {
                     docker_build(image_key)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -311,8 +311,6 @@ def get_pipeline(image_key) {
 
                 if (image_key == clangformat_os) {
                     docker_formatting(image_key)
-                    docker_cppcheck(image_key)
-		    recordIssues sourceCodeEncoding: 'UTF-8', qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]], tools: [cppCheck(pattern: 'cppcheck.txt', reportEncoding: 'UTF-8')]
                 } else {
                     docker_build(image_key)
                     if (image_key == test_and_coverage_os && !env.CHANGE_ID) {
@@ -400,7 +398,7 @@ def get_system_tests_pipeline() {
                             """
 			}
                     }  // stage
-                }finally {
+                } finally {
 		    stage("System tests: Cleanup") {
                         sh """docker stop \$(docker ps -a -q) && docker rm \$(docker ps -a -q) || true
                         """
@@ -440,6 +438,11 @@ node('docker && eee') {
     }
 
     parallel builders
+	
+    stage('CppCheck') {
+	docker_cppcheck(clangformat_os)
+        recordIssues sourceCodeEncoding: 'UTF-8', qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]], tools: [cppCheck(pattern: 'cppcheck.txt', reportEncoding: 'UTF-8')]     
+    }
 
     // Delete workspace when build is done
     cleanWs()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -312,7 +312,7 @@ def get_pipeline(image_key) {
                 if (image_key == clangformat_os) {
                     docker_formatting(image_key)
                     docker_cppcheck(image_key)
-		    recordIssues qualityGates: [[threshold: 2, type: 'TOTAL', unstable: true]], tools: [cppCheck(pattern: 'cppcheck.txt')]
+		    recordIssues sourceCodeEncoding: 'UTF-8', qualityGates: [[threshold: 2, type: 'TOTAL', unstable: true]], tools: [cppCheck(pattern: 'cppcheck.txt', reportEncoding: 'UTF-8')]
                 } else {
                     docker_build(image_key)
                     if (image_key == test_and_coverage_os && !env.CHANGE_ID) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -312,7 +312,7 @@ def get_pipeline(image_key) {
                 if (image_key == clangformat_os) {
                     docker_formatting(image_key)
                     docker_cppcheck(image_key)
-                    step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']], unstableTotalAll: '10'])
+                    step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']], unstableTotalAll: '3'])
                 } else {
                     docker_build(image_key)
                     if (image_key == test_and_coverage_os && !env.CHANGE_ID) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -312,7 +312,7 @@ def get_pipeline(image_key) {
                 if (image_key == clangformat_os) {
                     docker_formatting(image_key)
                     docker_cppcheck(image_key)
-		    recordIssues sourceCodeEncoding: 'UTF-8', qualityGates: [[threshold: 2, type: 'TOTAL', unstable: true]], tools: [cppCheck(pattern: 'cppcheck.txt', reportEncoding: 'UTF-8')]
+		    recordIssues sourceCodeEncoding: 'UTF-8', qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]], tools: [cppCheck(pattern: 'cppcheck.txt', reportEncoding: 'UTF-8')]
                 } else {
                     docker_build(image_key)
                     if (image_key == test_and_coverage_os && !env.CHANGE_ID) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -312,7 +312,7 @@ def get_pipeline(image_key) {
                 if (image_key == clangformat_os) {
                     docker_formatting(image_key)
                     docker_cppcheck(image_key)
-                    step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']], unstableTotalAll: '2'])
+                    step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']], unstableTotalAll: '0'])
                 } else {
                     docker_build(image_key)
                     if (image_key == test_and_coverage_os && !env.CHANGE_ID) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -283,7 +283,7 @@ def docker_cppcheck(image_key) {
         def test_output = "cppcheck.txt"
         def cppcheck_script = """
                         cd forward-epics-to-kafka
-                        cppcheck --inline-suppr --enable=all --inconclusive --template="{file},{line},{severity},{id},{message}" src/ 2> ${test_output}
+                        cppcheck --inline-suppr --enable=all --inconclusive src/ 2> ${test_output}
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/forward-epics-to-kafka/${test_output} ."

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -312,7 +312,7 @@ def get_pipeline(image_key) {
                 if (image_key == clangformat_os) {
                     docker_formatting(image_key)
                     docker_cppcheck(image_key)
-                    step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']], unstableTotalAll: '0'])
+                    step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']], unstableTotalAll: '2'])
                 } else {
                     docker_build(image_key)
                     if (image_key == test_and_coverage_os && !env.CHANGE_ID) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -283,7 +283,7 @@ def docker_cppcheck(image_key) {
         def test_output = "cppcheck.txt"
         def cppcheck_script = """
                         cd forward-epics-to-kafka
-                        cppcheck --enable=all --inconclusive --template="{file},{line},{severity},{id},{message}" src/ 2> ${test_output}
+                        cppcheck --inline-suppr --enable=all --inconclusive --template="{file},{line},{severity},{id},{message}" src/ 2> ${test_output}
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/forward-epics-to-kafka/${test_output} ."

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -312,8 +312,7 @@ def get_pipeline(image_key) {
                 if (image_key == clangformat_os) {
                     docker_formatting(image_key)
                     docker_cppcheck(image_key)
-		    recordIssues qualityGates: [[threshold: 2, type: 'TOTAL', unstable: true]], tools: [cppCheck()]
-                    //step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']], unstableTotalAll: '2'])
+		    recordIssues qualityGates: [[threshold: 2, type: 'TOTAL', unstable: true]], tools: [cppCheck(pattern: 'cppcheck.txt')]
                 } else {
                     docker_build(image_key)
                     if (image_key == test_and_coverage_os && !env.CHANGE_ID) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -444,7 +444,7 @@ node('docker && eee') {
 	
     stage('CppCheck') {
 	docker_cppcheck(clangformat_os)
-        recordIssues sourceCodeEncoding: 'UTF-8', qualityGates: [[threshold: 1, type: 'TOTAL', unstable: false]], tools: [cppCheck(pattern: 'cppcheck.xml', reportEncoding: 'UTF-8')]
+        recordIssues sourceCodeEncoding: 'UTF-8', qualityGates: [[threshold: 2, type: 'TOTAL', unstable: true]], tools: [cppCheck(pattern: 'cppcheck.xml', reportEncoding: 'UTF-8')]
 	sh "docker stop ${container_name(clangformat_os)}"
         sh "docker rm -f ${container_name(clangformat_os)}"
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -312,7 +312,8 @@ def get_pipeline(image_key) {
                 if (image_key == clangformat_os) {
                     docker_formatting(image_key)
                     docker_cppcheck(image_key)
-                    step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']], unstableTotalAll: '2'])
+		    recordIssues healthy: 2, tools: [cppCheck()], unhealthy: 2
+                    //step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']], unstableTotalAll: '2'])
                 } else {
                     docker_build(image_key)
                     if (image_key == test_and_coverage_os && !env.CHANGE_ID) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -312,7 +312,7 @@ def get_pipeline(image_key) {
                 if (image_key == clangformat_os) {
                     docker_formatting(image_key)
                     docker_cppcheck(image_key)
-                    step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']], unstableTotalAll: '3'])
+                    step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']], unstableTotalAll: '2'])
                 } else {
                     docker_build(image_key)
                     if (image_key == test_and_coverage_os && !env.CHANGE_ID) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -444,7 +444,7 @@ node('docker && eee') {
 	
     stage('CppCheck') {
 	docker_cppcheck(clangformat_os)
-        recordIssues sourceCodeEncoding: 'UTF-8', qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]], tools: [cppCheck(pattern: 'cppcheck.xml', reportEncoding: 'UTF-8')]
+        recordIssues sourceCodeEncoding: 'UTF-8', qualityGates: [[threshold: 1, type: 'TOTAL', unstable: false]], tools: [cppCheck(pattern: 'cppcheck.xml', reportEncoding: 'UTF-8')]
 	sh "docker stop ${container_name(clangformat_os)}"
         sh "docker rm -f ${container_name(clangformat_os)}"
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -312,7 +312,7 @@ def get_pipeline(image_key) {
                 if (image_key == clangformat_os) {
                     docker_formatting(image_key)
                     docker_cppcheck(image_key)
-                    step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']], unstableTotalAll: 10])
+                    step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']], unstableTotalAll: '10'])
                 } else {
                     docker_build(image_key)
                     if (image_key == test_and_coverage_os && !env.CHANGE_ID) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -312,7 +312,7 @@ def get_pipeline(image_key) {
                 if (image_key == clangformat_os) {
                     docker_formatting(image_key)
                     docker_cppcheck(image_key)
-                    step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']]])
+                    step([$class: 'WarningsPublisher', parserConfigurations: [[parserName: 'Cppcheck Parser', pattern: 'cppcheck.txt']], unstableTotalAll: 10])
                 } else {
                     docker_build(image_key)
                     if (image_key == test_and_coverage_os && !env.CHANGE_ID) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -283,7 +283,7 @@ def docker_cppcheck(image_key) {
         def test_output = "cppcheck.txt"
         def cppcheck_script = """
                         cd forward-epics-to-kafka
-                        cppcheck --inline-suppr --enable=all --inconclusive src/ 2> ${test_output}
+                        cppcheck --xml --inline-suppr --enable=all --inconclusive src/ 2> ${test_output}
                     """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${cppcheck_script}\""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/forward-epics-to-kafka/${test_output} ."

--- a/src/EpicsClient/FwdMonitorRequester.cpp
+++ b/src/EpicsClient/FwdMonitorRequester.cpp
@@ -34,7 +34,7 @@ void FwdMonitorRequester::message(std::string const &Message,
       Message);
 }
 
-/// cppcheck-suppress unusedFunction
+// cppcheck-suppress unusedFunction
 void FwdMonitorRequester::monitorConnect(
     ::epics::pvData::Status const &Status,
     ::epics::pvData::Monitor::shared_pointer const &Monitor,

--- a/src/EpicsClient/FwdMonitorRequester.cpp
+++ b/src/EpicsClient/FwdMonitorRequester.cpp
@@ -56,6 +56,7 @@ void FwdMonitorRequester::monitorConnect(
   }
 }
 
+// cppcheck-suppress unusedFunction ; used inside EPICS
 void FwdMonitorRequester::monitorEvent(
     ::epics::pvData::MonitorPtr const &Monitor) {
   std::vector<std::shared_ptr<FlatBufs::EpicsPVUpdate>> Updates;

--- a/src/EpicsClient/FwdMonitorRequester.cpp
+++ b/src/EpicsClient/FwdMonitorRequester.cpp
@@ -34,6 +34,7 @@ void FwdMonitorRequester::message(std::string const &Message,
       Message);
 }
 
+/// cppcheck-suppress unusedFunction
 void FwdMonitorRequester::monitorConnect(
     ::epics::pvData::Status const &Status,
     ::epics::pvData::Monitor::shared_pointer const &Monitor,

--- a/src/EpicsClient/FwdMonitorRequester.cpp
+++ b/src/EpicsClient/FwdMonitorRequester.cpp
@@ -34,7 +34,7 @@ void FwdMonitorRequester::message(std::string const &Message,
       Message);
 }
 
-// cppcheck-suppress unusedFunction
+// cppcheck-suppress unusedFunction ; used inside EPICS
 void FwdMonitorRequester::monitorConnect(
     ::epics::pvData::Status const &Status,
     ::epics::pvData::Monitor::shared_pointer const &Monitor,

--- a/src/Forwarder.cpp
+++ b/src/Forwarder.cpp
@@ -310,7 +310,7 @@ void Forwarder::report_stats(int dt) {
   }
 }
 
-URI Forwarder::createTopicURI(ConverterSettings const &ConverterInfo) {
+URI Forwarder::createTopicURI(ConverterSettings const &ConverterInfo) const {
   URI BrokerURI;
   if (!main_opt.MainSettings.Brokers.empty()) {
     BrokerURI = main_opt.MainSettings.Brokers[0];
@@ -337,7 +337,6 @@ URI Forwarder::createTopicURI(ConverterSettings const &ConverterInfo) {
 
 void Forwarder::pushConverterToStream(ConverterSettings const &ConverterInfo,
                                       std::shared_ptr<Stream> &Stream) {
-
   // Check schema exists
   auto r1 = FlatBufs::SchemaRegistry::items().find(ConverterInfo.Schema);
   if (r1 == FlatBufs::SchemaRegistry::items().end()) {

--- a/src/Forwarder.h
+++ b/src/Forwarder.h
@@ -68,7 +68,7 @@ private:
   std::mutex converters_mutex;
   std::map<std::string, std::weak_ptr<Converter>> converters;
   std::mutex streams_mutex;
-  URI createTopicURI(ConverterSettings const &ConverterInfo);
+  URI createTopicURI(ConverterSettings const &ConverterInfo) const;
   std::mutex conversion_workers_mx;
   std::vector<std::unique_ptr<ConversionWorker>> conversion_workers;
   ConversionScheduler conversion_scheduler;

--- a/src/Kafka.h
+++ b/src/Kafka.h
@@ -20,7 +20,8 @@ namespace Forwarder {
 
 class InstanceSet {
 public:
-  static std::shared_ptr<InstanceSet> Set(KafkaW::BrokerSettings BrokerSettings);
+  static std::shared_ptr<InstanceSet>
+  Set(KafkaW::BrokerSettings BrokerSettings);
   static void clear();
   KafkaW::ProducerTopic SetUpProducerTopic(URI uri);
   int poll();

--- a/src/Kafka.h
+++ b/src/Kafka.h
@@ -20,7 +20,7 @@ namespace Forwarder {
 
 class InstanceSet {
 public:
-  static std::shared_ptr<InstanceSet> Set(KafkaW::BrokerSettings Settings);
+  static std::shared_ptr<InstanceSet> Set(KafkaW::BrokerSettings BrokerSettings);
   static void clear();
   KafkaW::ProducerTopic SetUpProducerTopic(URI uri);
   int poll();
@@ -29,7 +29,7 @@ public:
   InstanceSet(InstanceSet const &&) = delete;
 
 private:
-  explicit InstanceSet(KafkaW::BrokerSettings opt);
+  explicit InstanceSet(KafkaW::BrokerSettings BrokerSettings);
   std::unique_lock<std::mutex> getProducersByHostMutexLock();
   KafkaW::BrokerSettings BrokerSettings;
   std::mutex ProducersByHostMutex;

--- a/src/KafkaOutput.cpp
+++ b/src/KafkaOutput.cpp
@@ -27,5 +27,5 @@ int KafkaOutput::emit(std::unique_ptr<FlatBufs::FlatbufferMessage> fb) {
   return x;
 }
 
-std::string KafkaOutput::topic_name() { return Output.name(); }
+std::string KafkaOutput::topicName() const { return Output.name(); }
 } // namespace Forwarder

--- a/src/KafkaOutput.h
+++ b/src/KafkaOutput.h
@@ -13,7 +13,7 @@ public:
   explicit KafkaOutput(KafkaW::ProducerTopic &&OutputTopic);
   /// Hands off the message to Kafka
   int emit(std::unique_ptr<FlatBufs::FlatbufferMessage> fb);
-  std::string topic_name();
+  std::string topicName() const;
   KafkaW::ProducerTopic Output;
 };
 } // namespace Forwarder

--- a/src/KafkaW/Consumer.cpp
+++ b/src/KafkaW/Consumer.cpp
@@ -12,11 +12,12 @@
 
 namespace KafkaW {
 Consumer::Consumer(BrokerSettings &Settings)
-    : ConsumerBrokerSettings(std::move(Settings)) {
+    : ConsumerBrokerSettings(std::move(Settings)),
+    Conf(std::unique_ptr<RdKafka::Conf>(
+        RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL)))
+    {
   std::string ErrorString;
 
-  Conf = std::unique_ptr<RdKafka::Conf>(
-      RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL));
   Conf->set("event_cb", &EventCallback, ErrorString);
   Conf->set("metadata.broker.list", ConsumerBrokerSettings.Address,
             ErrorString);
@@ -72,7 +73,6 @@ Consumer::getTopicPartitionNumbers(const std::string &Topic) {
   const RdKafka::TopicMetadata::PartitionMetadataVector *PartitionMetadata =
       matchedTopic->partitions();
 
-  // cppcheck-suppress useStlAlgorithm ; readability
   for (const auto &Partition : *PartitionMetadata) {
     TopicPartitionNumbers.push_back(Partition->id());
   }

--- a/src/KafkaW/Consumer.cpp
+++ b/src/KafkaW/Consumer.cpp
@@ -74,6 +74,7 @@ Consumer::getTopicPartitionNumbers(const std::string &Topic) {
       matchedTopic->partitions();
 
   for (const auto &Partition : *PartitionMetadata) {
+    // cppcheck-suppress useStlAlgorithm ; readability
     TopicPartitionNumbers.push_back(Partition->id());
   }
 

--- a/src/KafkaW/Consumer.cpp
+++ b/src/KafkaW/Consumer.cpp
@@ -71,9 +71,12 @@ Consumer::getTopicPartitionNumbers(const std::string &Topic) {
   std::vector<int32_t> TopicPartitionNumbers;
   const RdKafka::TopicMetadata::PartitionMetadataVector *PartitionMetadata =
       matchedTopic->partitions();
+
+  // cppcheck-suppress useStlAlgorithm ; readability
   for (const auto &Partition : *PartitionMetadata) {
     TopicPartitionNumbers.push_back(Partition->id());
   }
+
   sort(TopicPartitionNumbers.begin(), TopicPartitionNumbers.end());
   return TopicPartitionNumbers;
 }

--- a/src/KafkaW/Consumer.cpp
+++ b/src/KafkaW/Consumer.cpp
@@ -13,9 +13,8 @@
 namespace KafkaW {
 Consumer::Consumer(BrokerSettings &Settings)
     : ConsumerBrokerSettings(std::move(Settings)),
-    Conf(std::unique_ptr<RdKafka::Conf>(
-        RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL)))
-    {
+      Conf(std::unique_ptr<RdKafka::Conf>(
+          RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL))) {
   std::string ErrorString;
 
   Conf->set("event_cb", &EventCallback, ErrorString);

--- a/src/KafkaW/Consumer.h
+++ b/src/KafkaW/Consumer.h
@@ -40,9 +40,9 @@ protected:
   std::unique_ptr<RdKafka::KafkaConsumer> KafkaConsumer;
 
 private:
+  BrokerSettings ConsumerBrokerSettings;
   std::unique_ptr<RdKafka::Metadata> Metadata;
   std::unique_ptr<RdKafka::Conf> Conf;
-  BrokerSettings ConsumerBrokerSettings;
   KafkaEventCb EventCallback;
 
   /// Get all partition numbers for a topic.

--- a/src/KafkaW/Producer.cpp
+++ b/src/KafkaW/Producer.cpp
@@ -27,8 +27,8 @@ Producer::~Producer() {
 
 Producer::Producer(BrokerSettings Settings)
     : ProducerBrokerSettings(std::move(Settings)),
-    Conf(std::unique_ptr<RdKafka::Conf>(
-        RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL))){
+      Conf(std::unique_ptr<RdKafka::Conf>(
+          RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL))) {
   ProducerID = ProducerInstanceCount++;
 
   std::string ErrorString;

--- a/src/KafkaW/Producer.cpp
+++ b/src/KafkaW/Producer.cpp
@@ -26,13 +26,13 @@ Producer::~Producer() {
 }
 
 Producer::Producer(BrokerSettings Settings)
-    : ProducerBrokerSettings(std::move(Settings)) {
+    : ProducerBrokerSettings(std::move(Settings)),
+    Conf(std::unique_ptr<RdKafka::Conf>(
+        RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL))){
   ProducerID = ProducerInstanceCount++;
 
   std::string ErrorString;
 
-  Conf = std::unique_ptr<RdKafka::Conf>(
-      RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL));
   try {
     ProducerBrokerSettings.apply(Conf.get());
   } catch (std::runtime_error &e) {

--- a/src/KafkaW/ProducerStats.h
+++ b/src/KafkaW/ProducerStats.h
@@ -14,8 +14,8 @@ struct ProducerStats {
   std::atomic<uint64_t> produced_bytes{0};
   std::atomic<uint32_t> out_queue{0};
   ProducerStats() = default;
-  // cppcheck-suppress useInitializationList
   ProducerStats(ProducerStats const &x) {
+    // cppcheck-suppress useInitializationList
     produced = x.produced.load();
     produce_fail = x.produce_fail.load();
     local_queue_full = x.local_queue_full.load();

--- a/src/KafkaW/ProducerStats.h
+++ b/src/KafkaW/ProducerStats.h
@@ -14,6 +14,7 @@ struct ProducerStats {
   std::atomic<uint64_t> produced_bytes{0};
   std::atomic<uint32_t> out_queue{0};
   ProducerStats() = default;
+  // cppcheck-suppress useInitializationList
   ProducerStats(ProducerStats const &x) {
     produced = x.produced.load();
     produce_fail = x.produce_fail.load();

--- a/src/Stream.cpp
+++ b/src/Stream.cpp
@@ -42,12 +42,12 @@ nlohmann::json ConversionPath::status_json() const {
   auto Document = json::object();
   Document["schema"] = converter->schema_name();
   Document["broker"] = kafka_output->Output.brokerAddress();
-  Document["topic"] = kafka_output->topic_name();
+  Document["topic"] = kafka_output->topicName();
   return Document;
 }
 
 std::string ConversionPath::getKafkaTopicName() const {
-  return kafka_output->topic_name();
+  return kafka_output->topicName();
 }
 
 std::string ConversionPath::getSchemaName() const {

--- a/src/URI.h
+++ b/src/URI.h
@@ -27,6 +27,6 @@ struct URI {
   std::string Topic;
 
   /// The URI string //<host>:<port>/<topic>
-  std::string getURIString() { return "//" + HostPort + "/" + Topic; }
+  std::string getURIString() const { return "//" + HostPort + "/" + Topic; }
 };
 } // namespace Forwarder

--- a/src/tests/BrokerSettings_tests.cpp
+++ b/src/tests/BrokerSettings_tests.cpp
@@ -11,8 +11,6 @@ using ::testing::Return;
 using namespace KafkaW;
 
 class BrokerSettingsTests : public ::testing::Test {
-protected:
-  void SetUp() override {}
 };
 
 TEST_F(BrokerSettingsTests, callingApplyCallsSetOnKafkaConfObject) {

--- a/src/tests/BrokerSettings_tests.cpp
+++ b/src/tests/BrokerSettings_tests.cpp
@@ -10,8 +10,7 @@ using ::testing::Return;
 
 using namespace KafkaW;
 
-class BrokerSettingsTests : public ::testing::Test {
-};
+class BrokerSettingsTests : public ::testing::Test {};
 
 TEST_F(BrokerSettingsTests, callingApplyCallsSetOnKafkaConfObject) {
   BrokerSettings Settings;

--- a/src/tests/CommandHandler_tests.cpp
+++ b/src/tests/CommandHandler_tests.cpp
@@ -114,6 +114,7 @@ TEST(CommandHandlerTest, stop_command_removes_stream_correctly) {
 }
 
 class ExtractCommandsTest : public ::testing::TestWithParam<const char *> {
+  // cppcheck-suppress unusedFunction
   void SetUp() override { command = (*GetParam()); }
 
 protected:

--- a/src/tests/CommandHandler_tests.cpp
+++ b/src/tests/CommandHandler_tests.cpp
@@ -115,7 +115,6 @@ TEST(CommandHandlerTest, stop_command_removes_stream_correctly) {
 
 class ExtractCommandsTest : public ::testing::TestWithParam<const char *> {
   void SetUp() override { command = (*GetParam()); }
-  void TearDown() override {}
 
 protected:
   std::string command;

--- a/src/tests/Consumer_tests.cpp
+++ b/src/tests/Consumer_tests.cpp
@@ -103,7 +103,7 @@ public:
 
 class ConsumerStandIn : public Consumer {
 public:
- explicit ConsumerStandIn(BrokerSettings &Settings) : Consumer(Settings) {}
+  explicit ConsumerStandIn(BrokerSettings &Settings) : Consumer(Settings) {}
   using Consumer::KafkaConsumer;
 };
 

--- a/src/tests/Consumer_tests.cpp
+++ b/src/tests/Consumer_tests.cpp
@@ -103,7 +103,7 @@ public:
 
 class ConsumerStandIn : public Consumer {
 public:
-  ConsumerStandIn(BrokerSettings &Settings) : Consumer(Settings) {}
+ explicit ConsumerStandIn(BrokerSettings &Settings) : Consumer(Settings) {}
   using Consumer::KafkaConsumer;
 };
 

--- a/src/tests/ProducerDeliveryCb_tests.cpp
+++ b/src/tests/ProducerDeliveryCb_tests.cpp
@@ -14,7 +14,7 @@ protected:
 };
 
 struct ProducerMessageStandIn : ProducerMessage {
-  ProducerMessageStandIn(std::function<void()> DestructorFunction)
+  explicit ProducerMessageStandIn(std::function<void()> DestructorFunction)
       : Fun(DestructorFunction) {}
   ~ProducerMessageStandIn() override { Fun(); }
   std::function<void()> Fun;

--- a/src/tests/Producer_tests.cpp
+++ b/src/tests/Producer_tests.cpp
@@ -69,7 +69,7 @@ class FakeTopic : public RdKafka::Topic {
 public:
   FakeTopic() = default;
   ~FakeTopic() override = default;
-  const std::string name() const override{};
+  const std::string name() const override {};
   bool partition_available(int32_t partition) const override { return true; };
   RdKafka::ErrorCode offset_store(int32_t partition, int64_t offset) override{};
   struct rd_kafka_topic_s *c_ptr() override{};

--- a/src/tests/Producer_tests.cpp
+++ b/src/tests/Producer_tests.cpp
@@ -70,7 +70,9 @@ public:
   FakeTopic() = default;
   ~FakeTopic() override = default;
   const std::string name() const override {};
+  // cppcheck-suppress unusedFunction
   bool partition_available(int32_t partition) const override { return true; };
+  // cppcheck-suppress unusedFunction
   RdKafka::ErrorCode offset_store(int32_t partition, int64_t offset) override{};
   struct rd_kafka_topic_s *c_ptr() override{};
 };

--- a/src/tests/Producer_tests.cpp
+++ b/src/tests/Producer_tests.cpp
@@ -69,7 +69,7 @@ class FakeTopic : public RdKafka::Topic {
 public:
   FakeTopic() = default;
   ~FakeTopic() override = default;
-  const std::string name() const override {};
+  const std::string name() const override{};
   // cppcheck-suppress unusedFunction
   bool partition_available(int32_t partition) const override { return true; };
   // cppcheck-suppress unusedFunction


### PR DESCRIPTION
### Issue

N/A

### Description of work

@SkyToGround did a great job fixing cppcheck warnings: let's not let that go to waste.
I have added a check to Jenkins that will make the build unstable if the number of warnings exceeds n, where n is the current number of warnings (n = 2).

One of the current warnings is nonsense and unavoidable (missingInclude) the other might be legit (something to do with the GELF stuff).

I have fixed a small number of warnings and suppressed some others too.

### Nominate for Group Code Review

- [ ] Nominate for code review 
