### PR TITLE
Add sufficient producer poll calls

### DIFF
--- a/src/KafkaW/Producer.cpp
+++ b/src/KafkaW/Producer.cpp
@@ -74,6 +74,13 @@ RdKafka::ErrorCode Producer::produce(RdKafka::Topic *Topic, int32_t Partition,
                                      int MessageFlags, void *Payload,
                                      size_t PayloadSize, const void *Key,
                                      size_t KeySize, void *OpaqueMessage) {
+  // Do a non-blocking poll of the local producer (note this is not polling
+  // anything across the network)
+  // NB, if we don't call poll then we haven't handled successful publishing of
+  // each message and the messages therefore never get removed from librdkafka's
+  // producer queue
+  ProducerPtr->poll(0);
+
   return dynamic_cast<RdKafka::Producer *>(ProducerPtr.get())
       ->produce(Topic, Partition, MessageFlags, Payload, PayloadSize, Key,
                 KeySize, OpaqueMessage);


### PR DESCRIPTION
### Issue
DM-1480


Prior to these changes RdKafka::Producer.poll() may not be called sufficiently frequently when producing at a high rate. This results in successful publish events not getting handled, therefore RdKafka does not clear the messages from the producer queue, it eventually fills up completely and at that point message publishing fails.

### Description of work

I've added a test to `Producer_tests.cpp` which checks that `poll` is called each time we call produce. I've added a non-blocking call to `poll` in produce. Note, there is no significant performance hit from this, it only polls the local producer, it does not do anything across the network.

@mattclarke The changes are identical to those made in the File Writer except that the unit test uses gmock rather than trompeloeil.

### Nominate for Group Code Review

- [ ] Nominate for code review 
