### PR TITLE
Improve/fix URI code and related error messages

### DIFF
--- a/src/ConfigParser.h
+++ b/src/ConfigParser.h
@@ -26,7 +26,7 @@ struct StreamSettings {
 
 /// Holder for the configuration settings defined in the configuration file.
 struct ConfigSettings {
-  URI BrokerConfig{"//localhost:9092/forward_epics_to_kafka_commands"};
+  URI BrokerConfig{"localhost:9092/forward_epics_to_kafka_commands"};
   std::vector<URI> Brokers;
   size_t ConversionThreads{1};
   size_t ConversionWorkerQueueSize{1024};

--- a/src/MainOpt.cpp
+++ b/src/MainOpt.cpp
@@ -45,8 +45,9 @@ std::vector<StreamSettings> parseStreamsJson(const std::string &filepath) {
 
 /// Add a URI valued option to the given App.
 CLI::Option *addUriOption(CLI::App &App, std::string const &Name,
-                       Forwarder::URI &URIArg, std::string const &Description,
-                       bool Defaulted = false) {
+                          Forwarder::URI &URIArg,
+                          std::string const &Description,
+                          bool Defaulted = false) {
   CLI::callback_t Fun = [&URIArg](CLI::results_t Results) {
     try {
       URIArg.parse(Results[0]);
@@ -58,8 +59,7 @@ CLI::Option *addUriOption(CLI::App &App, std::string const &Name,
   CLI::Option *Opt = App.add_option(Name, Fun, Description, Defaulted);
   Opt->set_custom_option("URI", 1);
   if (Defaulted) {
-    Opt->set_default_str(URIArg.HostPort + "/" +
-                         URIArg.Topic);
+    Opt->set_default_str(URIArg.HostPort + "/" + URIArg.Topic);
   }
   return Opt;
 }
@@ -123,12 +123,12 @@ std::pair<int, std::unique_ptr<MainOpt>> parse_opt(int argc, char **argv) {
   App.add_option("-v,--verbosity", log_level, "Syslog logging level", true)
       ->check(CLI::Range(1, 7));
   addUriOption(App, "--config-topic", opt.MainSettings.BrokerConfig,
-            "<host[:port]/topic> Kafka host/topic to listen for commands on",
-            true)
+               "<host[:port]/topic> Kafka host/topic to listen for commands on",
+               true)
       ->required();
   addUriOption(App, "--status-topic", opt.MainSettings.StatusReportURI,
-            "<host[:port][/topic]> Kafka broker/topic to publish status "
-            "updates on");
+               "<host[:port][/topic]> Kafka broker/topic to publish status "
+               "updates on");
   App.add_option("--pv-update-period", opt.PeriodMS,
                  "Force forwarding all PVs with this period even if values "
                  "are not updated (ms). 0=Off",

--- a/src/URI.cpp
+++ b/src/URI.cpp
@@ -8,21 +8,24 @@ namespace Forwarder {
 
 URI::URI(const std::string &URIString) { parse(URIString); }
 
-void URI::parse(const std::string &URIString) {
-  std::smatch Matches;
-  // This is a modified version of the RFC-3986 Regex for capturing URIs. The
-  // host is mandatory however scheme and port are optional. Uses capture groups
-  // for each component of the URI and ignores any paths
-  std::regex Regex(
-      R"(\s*(([^:/?#]+):)?//((([^/?#:]+)+)(:(\d+))?)/?([a-zA-Z0-9._-]+)?\s*)");
-  std::regex_match(URIString, Matches, Regex);
-  if (!Matches[4].matched) {
-    throw std::runtime_error("Host not found when trying to parse URI");
+  void URI::parse(const std::string &URIString) {
+    std::smatch Matches;
+    // This is a modified version of the RFC-3986 Regex for capturing URIs. The
+    // host is mandatory however scheme and port are optional. Uses capture groups
+    // for each component of the URI and ignores any paths
+    std::regex Regex(
+                     R"(\s*((([^:/?#]+)://)|(//)|())((([^/?#:]+)+)(:(\d+))?)/?([a-zA-Z0-9._-]+)?\s*)");
+    std::regex_match(URIString, Matches, Regex);
+    if (!Matches[6].matched) {
+      throw std::runtime_error("Unable to extract host from the URI: \"" +
+                               URIString + "\".");
+    }
+    HostPort = Matches[6].str();
+    if (Matches[10].matched) {
+      Port = static_cast<uint32_t>(std::stoi(Matches[10].str()));
+    }
+    if (Matches[11].matched) {
+      Topic = Matches[11].str();
+    }
   }
-  HostPort = Matches.str(3);
-  if (Matches[7].matched)
-    Port = static_cast<uint32_t>(std::stoi(Matches.str(7)));
-  if (Matches[8].matched)
-    Topic = Matches.str(8);
-}
 } // namespace Forwarder

--- a/src/URI.cpp
+++ b/src/URI.cpp
@@ -8,24 +8,24 @@ namespace Forwarder {
 
 URI::URI(const std::string &URIString) { parse(URIString); }
 
-  void URI::parse(const std::string &URIString) {
-    std::smatch Matches;
-    // This is a modified version of the RFC-3986 Regex for capturing URIs. The
-    // host is mandatory however scheme and port are optional. Uses capture groups
-    // for each component of the URI and ignores any paths
-    std::regex Regex(
-                     R"(\s*((([^:/?#]+)://)|(//)|())((([^/?#:]+)+)(:(\d+))?)/?([a-zA-Z0-9._-]+)?\s*)");
-    std::regex_match(URIString, Matches, Regex);
-    if (!Matches[6].matched) {
-      throw std::runtime_error("Unable to extract host from the URI: \"" +
-                               URIString + "\".");
-    }
-    HostPort = Matches[6].str();
-    if (Matches[10].matched) {
-      Port = static_cast<uint32_t>(std::stoi(Matches[10].str()));
-    }
-    if (Matches[11].matched) {
-      Topic = Matches[11].str();
-    }
+void URI::parse(const std::string &URIString) {
+  std::smatch Matches;
+  // This is a modified version of the RFC-3986 Regex for capturing URIs. The
+  // host is mandatory however scheme and port are optional. Uses capture groups
+  // for each component of the URI and ignores any paths
+  std::regex Regex(
+      R"(\s*((([^:/?#]+)://)|(//)|())((([^/?#:]+)+)(:(\d+))?)/?([a-zA-Z0-9._-]+)?\s*)");
+  std::regex_match(URIString, Matches, Regex);
+  if (!Matches[6].matched) {
+    throw std::runtime_error("Unable to extract host from the URI: \"" +
+                             URIString + "\".");
   }
+  HostPort = Matches[6].str();
+  if (Matches[10].matched) {
+    Port = static_cast<uint32_t>(std::stoi(Matches[10].str()));
+  }
+  if (Matches[11].matched) {
+    Topic = Matches[11].str();
+  }
+}
 } // namespace Forwarder

--- a/src/URI.h
+++ b/src/URI.h
@@ -6,27 +6,27 @@
 
 namespace Forwarder {
 
-  /// \brief Thin parser for URIs.
-  struct URI {
-    URI() = default;
-    /// Creates and parses the given URI
-    explicit URI(const std::string &URIString);
-    
-    /// Parses the given `uri`
-    void parse(const std::string &URIString);
-    
-    /// \brief If port was specified (or already non-zero before `URI::parse`) it
-    /// contains `host:port`.
-    std::string HostPort;
-    
-    /// \brief The port number if specified, or zero to indicate that the port is
-    /// not specified.
-    uint32_t Port = 0;
-    
-    /// If the path can be a valid Kafka topic name, then it is non-empty.
-    std::string Topic;
-    
-    /// The URI string <host>:<port>/<topic>
-    std::string getURIString() const { return HostPort + "/" + Topic; }
-  };
+/// \brief Thin parser for URIs.
+struct URI {
+  URI() = default;
+  /// Creates and parses the given URI
+  explicit URI(const std::string &URIString);
+
+  /// Parses the given `uri`
+  void parse(const std::string &URIString);
+
+  /// \brief If port was specified (or already non-zero before `URI::parse`) it
+  /// contains `host:port`.
+  std::string HostPort;
+
+  /// \brief The port number if specified, or zero to indicate that the port is
+  /// not specified.
+  uint32_t Port = 0;
+
+  /// If the path can be a valid Kafka topic name, then it is non-empty.
+  std::string Topic;
+
+  /// The URI string <host>:<port>/<topic>
+  std::string getURIString() const { return HostPort + "/" + Topic; }
+};
 } // namespace Forwarder

--- a/src/URI.h
+++ b/src/URI.h
@@ -6,27 +6,27 @@
 
 namespace Forwarder {
 
-/// \brief Thin parser for URIs.
-struct URI {
-  URI() = default;
-  /// Creates and parses the given URI
-  explicit URI(const std::string &URIString);
-
-  /// Parses the given `uri`
-  void parse(const std::string &URIString);
-
-  /// \brief If port was specified (or already non-zero before `URI::parse`) it
-  /// contains `host:port`.
-  std::string HostPort;
-
-  /// \brief The port number if specified, or zero to indicate that the port is
-  /// not specified.
-  uint32_t Port = 0;
-
-  /// If the path can be a valid Kafka topic name, then it is non-empty.
-  std::string Topic;
-
-  /// The URI string //<host>:<port>/<topic>
-  std::string getURIString() const { return "//" + HostPort + "/" + Topic; }
-};
+  /// \brief Thin parser for URIs.
+  struct URI {
+    URI() = default;
+    /// Creates and parses the given URI
+    explicit URI(const std::string &URIString);
+    
+    /// Parses the given `uri`
+    void parse(const std::string &URIString);
+    
+    /// \brief If port was specified (or already non-zero before `URI::parse`) it
+    /// contains `host:port`.
+    std::string HostPort;
+    
+    /// \brief The port number if specified, or zero to indicate that the port is
+    /// not specified.
+    uint32_t Port = 0;
+    
+    /// If the path can be a valid Kafka topic name, then it is non-empty.
+    std::string Topic;
+    
+    /// The URI string <host>:<port>/<topic>
+    std::string getURIString() const { return HostPort + "/" + Topic; }
+  };
 } // namespace Forwarder

--- a/src/tests/URI_tests.cpp
+++ b/src/tests/URI_tests.cpp
@@ -9,8 +9,20 @@ TEST(URI, host_only_gives_hostport_plus_default_port) {
   ASSERT_EQ(TestURI.Port, (uint32_t)0);
 }
 
+TEST(URI, address_only) {
+  URI TestURI("myhost");
+  ASSERT_EQ(TestURI.HostPort, "myhost");
+  ASSERT_EQ(TestURI.Port, (uint32_t)0);
+}
+
 TEST(URI, ip_only_gives_hostport_plus_default_port) {
   URI TestURI("//127.0.0.1");
+  ASSERT_EQ(TestURI.HostPort, "127.0.0.1");
+  ASSERT_EQ(TestURI.Port, (uint32_t)0);
+}
+
+TEST(URI, ip_only) {
+  URI TestURI("127.0.0.1");
   ASSERT_EQ(TestURI.HostPort, "127.0.0.1");
   ASSERT_EQ(TestURI.Port, (uint32_t)0);
 }
@@ -21,14 +33,32 @@ TEST(URI, host_with_port_gives_hostport_and_port) {
   ASSERT_EQ(TestURI.Port, (uint32_t)345);
 }
 
+TEST(URI, address_and_port) {
+  URI TestURI("myhost:345");
+  ASSERT_EQ(TestURI.HostPort, "myhost:345");
+  ASSERT_EQ(TestURI.Port, (uint32_t)345);
+}
+
 TEST(URI, getURIString_host_with_port_and_topic_gives_hostport_and_topic) {
-  std::string TestURIString = "//myhost:345/mytopic";
+  std::string TestURIString = "myhost:345/mytopic";
+  URI TestURI("//" + TestURIString);
+  ASSERT_EQ(TestURI.getURIString(), TestURIString);
+}
+
+TEST(URI, address_and_port_and_topic) {
+  std::string TestURIString = "myhost:345/mytopic";
   URI TestURI(TestURIString);
   ASSERT_EQ(TestURI.getURIString(), TestURIString);
 }
 
 TEST(URI, ip_with_port_gives_hostport_with_port) {
   URI TestURI("//127.0.0.1:345");
+  ASSERT_EQ(TestURI.HostPort, "127.0.0.1:345");
+  ASSERT_EQ(TestURI.Port, (uint32_t)345);
+}
+
+TEST(URI, ip_and_port) {
+  URI TestURI("127.0.0.1:345");
   ASSERT_EQ(TestURI.HostPort, "127.0.0.1:345");
   ASSERT_EQ(TestURI.Port, (uint32_t)345);
 }
@@ -81,5 +111,5 @@ TEST(URI, topic_picked_up_when_after_port) {
   ASSERT_EQ(TestURI.HostPort, "localhost:9092");
   ASSERT_EQ(TestURI.Port, 9092u);
   ASSERT_EQ(TestURI.Topic, "TEST_writerCommand");
-  ASSERT_EQ(TestURI.getURIString(), "//localhost:9092/TEST_writerCommand");
+  ASSERT_EQ(TestURI.getURIString(), "localhost:9092/TEST_writerCommand");
 }


### PR DESCRIPTION
### Issue

* DM-1444

### Description of work

* Made the forward slashes ("//") in URIs optional.
* Added some unit tests.
* Improved the exception error message when failing to parse host name.
* Made the CLI11 library write out an error message on (some) poorly formatted address strings.
* Removed references to the forward slashes from the help text.
* Improved a function name.

### Nominate for Group Code Review

- [ ] Nominate for code review 