### PR TITLE
Protect the cached update with a mutex

### DIFF
--- a/src/EpicsClient/EpicsClientInterface.h
+++ b/src/EpicsClient/EpicsClientInterface.h
@@ -9,7 +9,7 @@ namespace EpicsClient {
 class EpicsClientInterface {
 public:
   virtual ~EpicsClientInterface() = default;
-  virtual int emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> Update) = 0;
+  virtual void emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> Update) = 0;
   virtual int stop() = 0;
   virtual void errorInEpics() = 0;
   virtual int status() = 0;

--- a/src/EpicsClient/EpicsClientMonitor.cpp
+++ b/src/EpicsClient/EpicsClientMonitor.cpp
@@ -166,6 +166,7 @@ EpicsClientMonitor::~EpicsClientMonitor() {
 int EpicsClientMonitor::stop() { return Impl->stop(); }
 
 int EpicsClientMonitor::emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> Update) {
+  std::lock_guard<std::mutex> lock(CachedUpdateMutex);
   CachedUpdate = Update;
   return emitWithoutCaching(Update);
 }
@@ -173,6 +174,7 @@ int EpicsClientMonitor::emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> Update) {
 void EpicsClientMonitor::errorInEpics() { status_ = -1; }
 
 void EpicsClientMonitor::emitCachedValue() {
+  std::lock_guard<std::mutex> lock(CachedUpdateMutex);
   if (CachedUpdate != nullptr) {
     emitWithoutCaching(CachedUpdate);
   }

--- a/src/EpicsClient/EpicsClientMonitor.cpp
+++ b/src/EpicsClient/EpicsClientMonitor.cpp
@@ -120,16 +120,10 @@ public:
   }
 
   /// Pushes update to the emit_queue ring buffer which is owned by a stream.
-  int emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> const &Update) {
-#if TEST_PROVOKE_ERROR == 1
-    static std::atomic<int> c1{0};
-    if (c1 > 10) {
-      epics_client->error_in_epics();
-    }
-    ++c1;
-#endif
-    return epics_client->emit(Update);
+  void emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> const &Update) {
+    epics_client->emit(Update);
   }
+
   epics::pvData::MonitorRequester::shared_pointer monitor_requester;
   epics::pvAccess::ChannelProvider::shared_pointer provider;
   epics::pvAccess::ChannelRequester::shared_pointer channel_requester;
@@ -165,10 +159,10 @@ EpicsClientMonitor::~EpicsClientMonitor() {
 
 int EpicsClientMonitor::stop() { return Impl->stop(); }
 
-int EpicsClientMonitor::emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> Update) {
+void EpicsClientMonitor::emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> Update) {
   std::lock_guard<std::mutex> lock(CachedUpdateMutex);
   CachedUpdate = Update;
-  return emitWithoutCaching(Update);
+  emitWithoutCaching(Update);
 }
 
 void EpicsClientMonitor::errorInEpics() { status_ = -1; }
@@ -179,15 +173,10 @@ void EpicsClientMonitor::emitCachedValue() {
     emitWithoutCaching(CachedUpdate);
   }
 }
-int EpicsClientMonitor::emitWithoutCaching(
+void EpicsClientMonitor::emitWithoutCaching(
     std::shared_ptr<FlatBufs::EpicsPVUpdate> Update) {
-  if (!Update) {
-    Logger->info("empty update?");
-    // should never happen, ignore
-    return 1;
-  }
+  assert(Update != nullptr);
   EmitQueue->enqueue(Update);
-  return 0;
 }
 
 #define STRINGIFY2(x) #x

--- a/src/EpicsClient/EpicsClientMonitor.h
+++ b/src/EpicsClient/EpicsClientMonitor.h
@@ -34,9 +34,9 @@ public:
   /// Pushes the PV update onto the emit_queue ring buffer.
   ///
   /// \param Update An epics PV update holding the pv structure.
-  int emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> Update) override;
+  void emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> Update) override;
 
-  int emitWithoutCaching(std::shared_ptr<FlatBufs::EpicsPVUpdate> Update);
+  void emitWithoutCaching(std::shared_ptr<FlatBufs::EpicsPVUpdate> Update);
 
   /// Calls stop on the client implementation.
   int stop() override;

--- a/src/EpicsClient/EpicsClientMonitor.h
+++ b/src/EpicsClient/EpicsClientMonitor.h
@@ -55,6 +55,7 @@ private:
       moodycamel::ConcurrentQueue<std::shared_ptr<FlatBufs::EpicsPVUpdate>>>
       EmitQueue;
   std::shared_ptr<FlatBufs::EpicsPVUpdate> CachedUpdate;
+  std::mutex CachedUpdateMutex;
   std::atomic<int> status_{0};
   SharedLogger Logger = getLogger();
 };

--- a/src/EpicsClient/EpicsClientRandom.cpp
+++ b/src/EpicsClient/EpicsClientRandom.cpp
@@ -6,9 +6,8 @@
 namespace Forwarder {
 namespace EpicsClient {
 
-int EpicsClientRandom::emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> up) {
-  EmitQueue->enqueue(up);
-  return 1;
+void EpicsClientRandom::emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> Update) {
+  EmitQueue->enqueue(Update);
 }
 
 void EpicsClientRandom::generateFakePVUpdate() {

--- a/src/EpicsClient/EpicsClientRandom.h
+++ b/src/EpicsClient/EpicsClientRandom.h
@@ -20,7 +20,7 @@ public:
       : ChannelInformation(channelInfo), EmitQueue(std::move(RingBuffer)),
         UniformDistribution(0, 100){};
   ~EpicsClientRandom() override = default;
-  void emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> up) override;
+  void emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> Update) override;
   int stop() override { return 0; };
   void errorInEpics() override { status_ = -1; };
   int status() override { return status_; };

--- a/src/EpicsClient/EpicsClientRandom.h
+++ b/src/EpicsClient/EpicsClientRandom.h
@@ -20,7 +20,7 @@ public:
       : ChannelInformation(channelInfo), EmitQueue(std::move(RingBuffer)),
         UniformDistribution(0, 100){};
   ~EpicsClientRandom() override = default;
-  int emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> up) override;
+  void emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> up) override;
   int stop() override { return 0; };
   void errorInEpics() override { status_ = -1; };
   int status() override { return status_; };

--- a/src/EpicsClient/FwdMonitorRequester.cpp
+++ b/src/EpicsClient/FwdMonitorRequester.cpp
@@ -87,10 +87,7 @@ void FwdMonitorRequester::monitorEvent(
     Updates.push_back(Update);
   }
   for (auto &up : Updates) {
-    auto x = epics_client->emit(up);
-    if (x != 0) {
-      Logger->info("Cannot push update {}", up->channel);
-    }
+    epics_client->emit(up);
   }
 }
 

--- a/src/tests/StreamTestUtils.h
+++ b/src/tests/StreamTestUtils.h
@@ -4,9 +4,7 @@
 class FakeEpicsClient : public Forwarder::EpicsClient::EpicsClientInterface {
 public:
   FakeEpicsClient() = default;
-  int emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> /* Update */) override {
-    return 0;
-  }
+  void emit(std::shared_ptr<FlatBufs::EpicsPVUpdate> /* Update */) override {}
   int stop() override {
     IsStopped = true;
     return 0;


### PR DESCRIPTION
### Issue

DM-1505

### Description of work

Added mutex protection to the cached PV update used for the periodic update feature.

### Nominate for Group Code Review

- [ ] Nominate for code review 
