### PR TITLE
Replace unreliable system test

### DIFF
--- a/system-tests/helpers/kafka_helpers.py
+++ b/system-tests/helpers/kafka_helpers.py
@@ -30,7 +30,7 @@ def poll_for_valid_message(consumer, expected_file_identifier=b"f142"):
 
     :param consumer: The consumer object
     :param expected_file_identifier: The schema id we expect to find in the message
-    :return: The LogData flatbuffer from the message payload, the message key
+    :return: Tuple of the message payload and the key
     """
     msg = consumer.poll(timeout=1.0)
     assert msg is not None

--- a/system-tests/helpers/kafka_helpers.py
+++ b/system-tests/helpers/kafka_helpers.py
@@ -30,7 +30,7 @@ def poll_for_valid_message(consumer, expected_file_identifier=b"f142"):
 
     :param consumer: The consumer object
     :param expected_file_identifier: The schema id we expect to find in the message
-    :return: The LogData flatbuffer from the message payload
+    :return: The LogData flatbuffer from the message payload, the message key
     """
     msg = consumer.poll(timeout=1.0)
     assert msg is not None
@@ -42,9 +42,9 @@ def poll_for_valid_message(consumer, expected_file_identifier=b"f142"):
         assert (expected_file_identifier == message_file_id), \
             f"Expected message to have schema id of {expected_file_identifier}, but it has {message_file_id}"
     if expected_file_identifier == b"f142":
-        return LogData.LogData.GetRootAsLogData(msg.value(), 0)
+        return LogData.LogData.GetRootAsLogData(msg.value(), 0), msg.key()
     else:
-        return msg.value()
+        return msg.value(), msg.key()
 
 
 def create_consumer(offset_reset="earliest"):

--- a/system-tests/test_forwarding.py
+++ b/system-tests/test_forwarding.py
@@ -24,8 +24,9 @@ def test_config_file_channel_created_correctly(docker_compose):
     # Wait for PV to be updated
     sleep(5)
     # Check the initial value is forwarded
-    first_msg, _ = poll_for_valid_message(cons)
+    first_msg, msg_key = poll_for_valid_message(cons)
     check_expected_values(first_msg, Value.Double, PVDOUBLE, 0.0)
+    assert(msg_key == b'SIMPLE:DOUBLE'), 'Message key expected to be the same as the PV name'
 
     # Check the new value is forwarded
     second_msg, _ = poll_for_valid_message(cons)

--- a/system-tests/test_forwarding.py
+++ b/system-tests/test_forwarding.py
@@ -27,6 +27,8 @@ def test_config_file_channel_created_correctly(docker_compose):
     first_msg, msg_key = poll_for_valid_message(cons)
     check_expected_values(first_msg, Value.Double, PVDOUBLE, 0.0)
     assert(msg_key == b'SIMPLE:DOUBLE'), 'Message key expected to be the same as the PV name'
+    # We set the message key to be the PV name so that all messages from the same PV are sent to
+    # the same partition by Kafka. This ensures that the order of these messages is maintained to the consumer.
 
     # Check the new value is forwarded
     second_msg, _ = poll_for_valid_message(cons)

--- a/system-tests/test_forwarding.py
+++ b/system-tests/test_forwarding.py
@@ -24,10 +24,10 @@ def test_config_file_channel_created_correctly(docker_compose):
     # Wait for PV to be updated
     sleep(5)
     # Check the initial value is forwarded
-    first_msg = poll_for_valid_message(cons)
+    first_msg, _ = poll_for_valid_message(cons)
     check_expected_values(first_msg, Value.Double, PVDOUBLE, 0.0)
 
     # Check the new value is forwarded
-    second_msg = poll_for_valid_message(cons)
+    second_msg, _ = poll_for_valid_message(cons)
     check_expected_values(second_msg, Value.Double, PVDOUBLE, 10.0)
     cons.close()

--- a/system-tests/test_forwarding_no_command_at_startup.py
+++ b/system-tests/test_forwarding_no_command_at_startup.py
@@ -58,10 +58,10 @@ def test_forwarder_sends_pv_updates_single_pv_enum(docker_compose_no_command):
     sleep(5)
     cons.subscribe([data_topic])
 
-    first_msg = poll_for_valid_message(cons)
+    first_msg, _ = poll_for_valid_message(cons)
     check_expected_values(first_msg, Value.Int, PVENUM, 0)
 
-    second_msg = poll_for_valid_message(cons)
+    second_msg, _ = poll_for_valid_message(cons)
     check_expected_values(second_msg, Value.Int, PVENUM, 1)
     cons.close()
 
@@ -87,7 +87,7 @@ def test_forwarder_sends_pv_updates_single_floatarray(docker_compose_no_command)
     sleep(5)
     cons.subscribe([data_topic])
 
-    first_msg = poll_for_valid_message(cons)
+    first_msg, _ = poll_for_valid_message(cons)
     expectedarray = [1.1, 2.2, 3.3]
     check_expected_array_values(first_msg, Value.ArrayFloat, PVFLOATARRAY, expectedarray)
     cons.close()
@@ -113,8 +113,8 @@ def test_forwarder_updates_multiple_pvs(docker_compose_no_command):
 
     expected_values = {PVSTR: (Value.String, b''), PVLONG: (Value.Int, 0)}
 
-    first_msg = poll_for_valid_message(cons)
-    second_msg = poll_for_valid_message(cons)
+    first_msg, _ = poll_for_valid_message(cons)
+    second_msg, _ = poll_for_valid_message(cons)
     messages = [first_msg, second_msg]
 
     check_multiple_expected_values(messages, expected_values)
@@ -144,7 +144,7 @@ def test_forwarder_status_shows_added_pvs(docker_compose_no_command):
     _, hi = cons.get_watermark_offsets(partitions[0], cached=False, timeout=2.0)
     last_msg_offset = hi - 1
     cons.assign([TopicPartition(status_topic, partition=0, offset=last_msg_offset)])
-    status_msg = poll_for_valid_message(cons, expected_file_identifier=None)
+    status_msg, _ = poll_for_valid_message(cons, expected_file_identifier=None)
 
     status_json = json.loads(status_msg)
     names_of_channels_being_forwarded = {stream['channel_name'] for stream in status_json['streams']}
@@ -155,6 +155,7 @@ def test_forwarder_status_shows_added_pvs(docker_compose_no_command):
             f"but status message report these as forwarded: {names_of_channels_being_forwarded}"
 
     cons.close()
+
 
 def test_forwarder_updates_pv_when_config_change_add_two_pvs(docker_compose_no_command):
     """
@@ -178,64 +179,6 @@ def test_forwarder_updates_pv_when_config_change_add_two_pvs(docker_compose_no_c
 
     expected_values = {PVSTR: (Value.String, b''), PVLONG: (Value.Int, 0)}
 
-    messages = [poll_for_valid_message(cons), poll_for_valid_message(cons)]
+    messages = [poll_for_valid_message(cons)[0], poll_for_valid_message(cons)[0]]
     check_multiple_expected_values(messages, expected_values)
     cons.close()
-
-
-def test_updates_from_the_same_pv_reach_the_same_partition(docker_compose_no_command):
-    """
-    GIVEN Topic to publish data to has multiple partitions and multiple PVs are configured to be forwarded
-    WHEN PVs values change
-    THEN All PV updates for a particular PV are published to the same partition
-
-    We want updates for a particular PV to all reach the same partition in Kafka
-    so that their order is maintained
-    By default the messages would be published to different partitions
-    as a round robin approach is used to balance load, and this test would fail
-    But we have used the PV name as the message key, which should ensure
-    all messages from the same PV end up in the same partition
-    """
-    # This topic was created in the docker-compose and has 2 partitions
-    data_topic = "TEST_forwarderData_2_partitions"
-    pvs = [PVSTR, PVLONG]
-    prod = ProducerWrapper("localhost:9092", CONFIG_TOPIC, data_topic)
-    prod.add_config(pvs)
-
-    consumer_partition_0 = create_consumer()
-    consumer_partition_0.assign([TopicPartition(data_topic, partition=0)])
-
-    consumer_partition_1 = create_consumer()
-    consumer_partition_1.assign([TopicPartition(data_topic, partition=1)])
-
-    sleep(5)
-
-    # There should be 3 messages in total for each PV
-    # (the initial value and these two updates)
-    change_pv_value(PVSTR, "1")
-    sleep(0.5)
-    change_pv_value(PVSTR, "2")
-    sleep(0.5)
-
-    change_pv_value(PVLONG, 1)
-    sleep(0.5)
-    change_pv_value(PVLONG, 2)
-    sleep(0.5)
-
-    sleep(5)
-
-    def test_all_messages_for_pv_are_in_one_partition(consumer):
-        messages = get_all_available_messages(consumer)
-        # if we have any messages in this partition
-        if len(messages) != 0:
-            pv_name = messages[0].key()
-            assert pv_name is not None
-            count_of_messages_with_pv_name = sum(1 for message in messages if message.key() == pv_name)
-            # then we expect exactly 3 with the same key as the first message
-            assert count_of_messages_with_pv_name == 3
-            return True
-        return False
-
-    # Must find three messages with the same key in at least one of the two partitions
-    assert test_all_messages_for_pv_are_in_one_partition(consumer_partition_0) or \
-           test_all_messages_for_pv_are_in_one_partition(consumer_partition_1)

--- a/system-tests/test_generate_fake_epics_data.py
+++ b/system-tests/test_generate_fake_epics_data.py
@@ -10,6 +10,6 @@ def test_forwarder_sends_fake_pv_updates(docker_compose_fake_epics):
     data_topic = "TEST_forward_fake_generated_pvs"
     consumer.subscribe([data_topic])
     sleep(5)
-    msg = poll_for_valid_message(consumer)
+    msg, _ = poll_for_valid_message(consumer)
     # We should see PV updates in Kafka despite there being no IOC running
     check_expected_values(msg, Value.Value.Double, "FakePV", None)

--- a/system-tests/test_idle_pv_updates.py
+++ b/system-tests/test_idle_pv_updates.py
@@ -11,6 +11,6 @@ def test_forwarder_sends_idle_pv_updates(docker_compose_idle_updates):
     consumer.subscribe([data_topic])
     sleep(10)
     for i in range(3):
-        msg = poll_for_valid_message(consumer)
+        msg, _ = poll_for_valid_message(consumer)
         check_expected_values(msg, Value.Value.Double, PVDOUBLE, 0)
     consumer.close()

--- a/system-tests/test_idle_pv_updates_long_period.py
+++ b/system-tests/test_idle_pv_updates_long_period.py
@@ -11,7 +11,7 @@ def test_forwarder_does_not_send_pv_update_more_than_once_when_periodic_update_i
     data_topic = "TEST_forwarderData_long_idle_updates"
     consumer.subscribe([data_topic])
     sleep(3)
-    msg = poll_for_valid_message(consumer)
+    msg, _ = poll_for_valid_message(consumer)
     check_expected_values(msg, Value.Value.Double, PVDOUBLE, 0)
 
     with raises(MsgErrorException):

--- a/system-tests/test_longrunning.py
+++ b/system-tests/test_longrunning.py
@@ -29,10 +29,10 @@ def test_long_run(docker_compose_lr):
                 # Wait for the forwarder to push the update
                 sleep(3)
                 try:
-                    msg = poll_for_valid_message(cons)
+                    msg, _ = poll_for_valid_message(cons)
                 except MsgErrorException:
                     sleep(3)
-                    msg = poll_for_valid_message(cons)
+                    msg, _ = poll_for_valid_message(cons)
                 try:
                     check_expected_values(msg, Value.Double, PVDOUBLE, float(i))
                 except AssertionError:


### PR DESCRIPTION
### Issue

A system test which tried to check updates from the same PV end up in the same partition was unreliable.

### Description of work

Replaced the problem test with a simple check that the message key is set to the PV name. In other words, test that our code does what we intend rather than that Kafka itself behaves as we expect.

### Nominate for Group Code Review

- [ ] Nominate for code review 
