### PR TITLE
conan registry.json switch to remotes.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG https_proxy
 
 ARG local_conan_server
 
-ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/registry.json" "/root/.conan/registry.json"
+ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/remotes.json" "/root/.conan/remotes.json"
 ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/default_profile" "/root/.conan/profiles/default"
 
 COPY conan/ ../forwarder_src/conan/

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -2,11 +2,11 @@
 cmake_installer/3.10.0@conan/stable
 fmt/5.3.0@bincrafters/stable
 gtest/3121b20-dm3@ess-dmsc/stable
-FlatBuffers/1.9.0@ess-dmsc/stable
+flatbuffers/1.10.0@google/stable
 librdkafka/0.11.4@ess-dmsc/stable
 spdlog-graylog/1.2.1-dm8@ess-dmsc/testing
 epics/3.16.1-4.6.0-dm6@ess-dmsc/stable
-streaming-data-types/d429d55@ess-dmsc/stable
+streaming-data-types/c45d2ec@ess-dmsc/stable
 cli11/1.5.3@bincrafters/stable
 jsonformoderncpp/3.1.0@vthiery/stable
 concurrentqueue/8f7e861@ess-dmsc/stable

--- a/conan/conanfile_win32.txt
+++ b/conan/conanfile_win32.txt
@@ -1,9 +1,9 @@
 [requires]
 fmt/5.3.0@bincrafters/stable
-FlatBuffers/1.8.0@ess-dmsc/stable
+flatbuffers/1.10.0@google/stable
 librdkafka/0.11.3-dm3@ess-dmsc/testing
 epics/3.16.1-4.6.0-dm6@ess-dmsc/stable
-streaming-data-types/3e85b23@ess-dmsc/stable
+streaming-data-types/c45d2ec@ess-dmsc/stable
 cli11/1.5.3@bincrafters/stable
 jsonformoderncpp/3.1.0@vthiery/stable
 concurrentqueue/8f7e861@ess-dmsc/stable


### PR DESCRIPTION
### Issue

None

### Description of work

Switched to the remotes.json which is required for the most recent version of conan in the dockerfile for the system tests

- make sure the system tests pass

### Nominate for Group Code Review

- [ ] Nominate for code review 
