### PR TITLE
Tests were missing -Werror flag

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -30,5 +30,5 @@ target_link_libraries(tests
 if (WIN32)
     target_compile_options(tests PRIVATE /wd4996)
 else()
-    target_compile_options(tests PRIVATE -Wall -Wextra)
+    target_compile_options(tests PRIVATE -Wall -Wextra -Werror)
 endif(WIN32)


### PR DESCRIPTION
### Issue

N/A

### Description of work

The tests were building without the -Werror flag.

### Nominate for Group Code Review

- [ ] Nominate for code review 
