### PR TITLE
Update jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ builders = pipeline_builder.createBuilders { container ->
         container.sh """
             cd build
             . ./activate_run.sh
-            make VERBOSE=1
+            make VERBOSE=1 -j4
         """
     }  // stage
 
@@ -89,7 +89,7 @@ builders = pipeline_builder.createBuilders { container ->
                 cd build
                 . ./activate_run.sh
                 ./bin/tests -- --gtest_output=xml:${test_output}
-                make coverage
+                make coverage -j4
                 lcov --directory . --capture --output-file coverage.info
                 lcov --remove coverage.info '*_generated.h' '*/src/date/*' '*/.conan/data/*' '*/usr/*' --output-file coverage.info
                 pkill caRepeater || true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,11 +58,8 @@ builders = pipeline_builder.createBuilders { container ->
                 coverage_on = ""
             }
 
-            def configure_epics = ""
-
             container.sh """
                 cd build
-                ${configure_epics}
                 cmake -DCMAKE_BUILD_TYPE=Debug ../${pipeline_builder.project} ${coverage_on}
             """
         } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,10 +7,6 @@ project = "forward-epics-to-kafka"
 clangformat_os = "debian9"
 test_and_coverage_os = "centos7"
 release_os = "centos7-release"
-eee_os = "centos7"
-
-epics_dir = "/opt/epics"
-epics_profile_file = "/etc/profile.d/ess_epics_env.sh"
 
 // Set number of old builds to keep.
 properties([[
@@ -63,13 +59,6 @@ builders = pipeline_builder.createBuilders { container ->
             }
 
             def configure_epics = ""
-            //if (container.key == eee_os) {
-            //    // Only use the host machine's EPICS environment on eee_os
-            //    configure_epics = ". ${epics_profile_file}"
-            //} else {
-            //    // A problem is caused by "&& \" if left empty
-            //    configure_epics = "true"
-            //}
 
             container.sh """
                 cd build
@@ -281,7 +270,7 @@ def get_system_tests_pipeline() {
     }  // return
 }  // def
 
-node('docker && eee') {
+node {
     cleanWs()
 
     stage('Checkout') {
@@ -296,7 +285,7 @@ node('docker && eee') {
 
     builders['windows10'] = get_win10_pipeline()
 
-    if ( env.CHANGE_ID ) {
+    if (env.CHANGE_ID) {
         builders['system tests'] = get_system_tests_pipeline()
     }
 


### PR DESCRIPTION
### Issue

Update Jenkinsfile for parallel builds and remove `eee` label.

### Description of work

This PR removes unnecessary labels from the main node block, so that gets assigned to the Jenkins master (the `eee` label doesn't exist anymore on Jenkins). It also adds `-j4` to `make` invocations to speed up compilation.

### Nominate for Group Code Review

- [ ] Nominate for code review 