### PR TITLE
DM-1088: Add CMake versioning support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,14 @@ project(forward-epics-to-kafka)
 
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${PROJECT_SOURCE_DIR}/cmake")
 
+include(${CMAKE_MODULE_PATH}/Versioning.cmake)
+set_version()
+set(VERSION_INCLUDE_DIR ${CMAKE_BINARY_DIR}/version)
+create_version_header(
+  ${CMAKE_MODULE_PATH}/templates/Version.h.in
+  ${VERSION_INCLUDE_DIR}/Version.h
+)
+
 set (CMAKE_CXX_STANDARD 11)
 
 if (WIN32)

--- a/cmake/Versioning.cmake
+++ b/cmake/Versioning.cmake
@@ -1,0 +1,200 @@
+# Versioning.cmake
+#
+# Automated version string and variable definition and substitution based on the
+# ECDC versioning scheme.
+#
+# The version string is set according to the algorithm below:
+#
+#   if VERSION file with string X.Y.Z is present:
+#     VERSION_STRING = "X.Y.Z"
+#   else if Git is present and directory is a Git repository:
+#     VERSION_STRING = "<branch>-<commit>[-dirty]"
+#   else:
+#     VERSION_STRING = "dev"
+#
+# The version variables are set to the components "X", "Y" and "Z" if the
+# version string is "X.Y.Z". If the version string does not have that form, all
+# version variables are set to "0".
+#
+# Functions and macros exported by this module:
+#
+#   set_version() [function]
+#     Set version string variable according to the algorithm described above.
+#
+#   create_version_header(version_template_file output_version_file) [macro]
+#     Replace version string in template file, creating output file. To generate
+#     a new header file with an updated version string, CMake must be run again.
+#
+# Variables set by this module:
+#
+#   VERSION_STRING: the version string defined according to the algorithm above.
+#   MAJOR_VERSION: the major component of the version (X) or 0 if not defined.
+#   MINOR_VERSION: the minor component of the version (Y) or 0 if not defined.
+#   PATCH_VERSION: the patch component of the version (Z) or 0 if not defined.
+#
+# External requirements:
+#
+#   Git (if the file VERSION does not exist).
+#
+# Example usage:
+#
+#   # If the content of VERSION is "1.2.3", VERSION_STRING will be set to
+#   # "1.2.3". If that file does not exist and the current Git branch is
+#   # master on commit bc5b2c50e1fc8b1ce96607aa2f0d373900634389, with no
+#   # non-committed changes to tracked files, VERSION_STRING will be set to
+#   # "master-bc5b2c5".
+#
+#   # Call set_version in the main CMakeLists.txt file to define VERSION_STRING:
+#   set_version()
+#
+#   # Generate header file ${CMAKE_BINARY_DIR}/version/Version.h substituting
+#   # "@VERSION_STRING@" with the value of the variable in Version.h.in:
+#   create_version_header(Version.h.in ${CMAKE_BINARY_DIR}/version/Version.h)
+#
+
+# Set the DIRECTORY_IS_GIT_REPO variable if current directory is a Git
+# repository.
+function(is_directory_git_repo)
+  execute_process(
+    COMMAND           "${GIT_EXECUTABLE}" status
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    RESULT_VARIABLE   git_result
+    OUTPUT_VARIABLE   git_output
+    ERROR_VARIABLE    git_error
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+  )
+
+  if(git_result EQUAL 0)
+    set(DIRECTORY_IS_GIT_REPO TRUE PARENT_SCOPE)
+  else()
+    set(DIRECTORY_IS_GIT_REPO FALSE PARENT_SCOPE)
+  endif()
+endfunction()
+
+# Set the GIT_BRANCH variable to the current Git branch.
+function(set_git_branch_variable)
+  execute_process(
+    COMMAND           "${GIT_EXECUTABLE}" rev-parse --abbrev-ref HEAD
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    RESULT_VARIABLE   git_result
+    OUTPUT_VARIABLE   git_output
+    ERROR_VARIABLE    git_error
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+  )
+
+  if(git_result EQUAL 0)
+    set(GIT_BRANCH "${git_output}" PARENT_SCOPE)
+  else()
+    set(GIT_BRANCH "" PARENT_SCOPE)
+    message(
+      FATAL_ERROR
+      "Failed to get Git branch information with error ${git_error}"
+    )
+  endif()
+endfunction()
+
+# Set the GIT_SHORT_REF variable to the current Git ref.
+function(set_git_short_ref_variable)
+  execute_process(
+    COMMAND           "${GIT_EXECUTABLE}" rev-parse --short HEAD
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    RESULT_VARIABLE   git_result
+    OUTPUT_VARIABLE   git_output
+    ERROR_VARIABLE    git_error
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+  )
+
+  if(git_result EQUAL 0)
+    set(GIT_SHORT_REF "${git_output}" PARENT_SCOPE)
+  else()
+    set(GIT_SHORT_REF "" PARENT_SCOPE)
+    message(
+      FATAL_ERROR
+      "Failed to get Git ref information with error ${git_error}"
+    )
+  endif()
+endfunction()
+
+# Set the GIT_DIRTY variable to "-dirty" if there are non-committed changes to
+# the Git repository. If there are no changes, the variable is set to an empty
+# string.
+function(set_git_dirty_variable)
+  execute_process(
+    COMMAND           "${GIT_EXECUTABLE}" diff-index --quiet HEAD
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    RESULT_VARIABLE   git_result
+    OUTPUT_VARIABLE   git_output
+    ERROR_VARIABLE    git_error
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+  )
+
+  if(git_result EQUAL 0)
+    set(GIT_DIRTY "" PARENT_SCOPE)
+  else()
+    set(GIT_DIRTY "-dirty" PARENT_SCOPE)
+  endif()
+endfunction()
+
+# Set VERSION_STRING if the argument has the form "X.Y.Z" and version variables
+# to the value of the components.
+macro(match_and_set_version_variables version)
+  if("${version}" MATCHES "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$")
+    set(VERSION_STRING ${version} PARENT_SCOPE)
+    set(MAJOR_VERSION "${CMAKE_MATCH_1}" PARENT_SCOPE)
+    set(MINOR_VERSION "${CMAKE_MATCH_2}" PARENT_SCOPE)
+    set(PATCH_VERSION "${CMAKE_MATCH_3}" PARENT_SCOPE)
+  else()
+    message(FATAL_ERROR "Version ${version} does not match format X.Y.Z")
+  endif()
+endmacro()
+
+# Set VERSION_STRING to "<branch>-<commit>[-dirty]" and all version variables
+# to "0".
+macro(set_version_variables_from_git_branch_and_commit)
+  set_git_branch_variable()
+  set_git_short_ref_variable()
+  set_git_dirty_variable()
+  set(VERSION_STRING "${GIT_BRANCH}-${GIT_SHORT_REF}${GIT_DIRTY}" PARENT_SCOPE)
+  set(MAJOR_VERSION "0" PARENT_SCOPE)
+  set(MINOR_VERSION "0" PARENT_SCOPE)
+  set(PATCH_VERSION "0" PARENT_SCOPE)
+endmacro()
+
+# Set VERSION_STRING to "dev".
+macro(set_version_variables_to_constant_string)
+  set(VERSION_STRING "dev" PARENT_SCOPE)
+  set(MAJOR_VERSION "0" PARENT_SCOPE)
+  set(MINOR_VERSION "0" PARENT_SCOPE)
+  set(PATCH_VERSION "0" PARENT_SCOPE)
+endmacro()
+
+# Set version string variable to release version, Git branch and commit or
+# constant string.
+function(set_version)
+  if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/VERSION")
+    file(STRINGS "${CMAKE_CURRENT_LIST_DIR}/VERSION" RELEASE_VERSION)
+    match_and_set_version_variables("${RELEASE_VERSION}")
+  else()
+    find_package(Git)
+    if(GIT_FOUND)
+      is_directory_git_repo()
+      if(DIRECTORY_IS_GIT_REPO)
+        set_version_variables_from_git_branch_and_commit()
+      else()
+        set_version_variables_to_constant_string()
+      endif()
+    else()
+      set_version_variables_to_constant_string()
+    endif()
+  endif()
+endfunction()
+
+# Replace version string in template file and output header file in current
+# build folder.
+macro(create_version_header version_template_file output_version_file)
+  configure_file(${version_template_file} ${output_version_file})
+endmacro()

--- a/cmake/templates/Version.h.in
+++ b/cmake/templates/Version.h.in
@@ -1,0 +1,8 @@
+#include <string>
+
+inline static const std::string GetVersion() {
+  // The following line is executed only once on startup or on first call to
+  // function.
+  const static std::string Version = "@VERSION_STRING@";
+  return Version;
+}

--- a/cmake/templates/Version.h.in
+++ b/cmake/templates/Version.h.in
@@ -1,8 +1,11 @@
 #include <string>
 
+namespace Versioning {
+
 inline static const std::string GetVersion() {
   // The following line is executed only once on startup or on first call to
   // function.
   const static std::string Version = "@VERSION_STRING@";
   return Version;
 }
+} // namespace Versioning

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,6 +140,7 @@ add_library(forwarder-library ${forwarder-library_SRC} ${forwarder-library_INC})
 target_compile_definitions(forwarder-library PRIVATE ${compile_defs_common})
 target_link_libraries(forwarder-library ${libraries_common})
 target_include_directories(forwarder-library SYSTEM PUBLIC ${path_include_common} INTERFACE ".")
+target_include_directories(forwarder-library PRIVATE ${VERSION_INCLUDE_DIR})
 
 if (WIN32)
     target_link_libraries(forwarder-library Ws2_32.lib dbghelp.lib)

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -63,7 +63,9 @@ int main(int argc, char **argv) {
   auto op = Forwarder::parse_opt(argc, argv);
   auto &opt = *op.second;
 
-  if (op.first != 0) {
+  if (op.first == Forwarder::ParseOptRet::VersionRequested) {
+    return 0;
+  } else if (op.first == Forwarder::ParseOptRet::Error) {
     return 1;
   }
 

--- a/src/MainOpt.cpp
+++ b/src/MainOpt.cpp
@@ -207,7 +207,7 @@ std::pair<ParseOptRet, std::unique_ptr<MainOpt>> parse_opt(int argc,
   }
 
   if (MainOptions.PrintVersion) {
-    fmt::print("{}\n", GetVersion());
+    fmt::print("{}\n", Versioning::GetVersion());
     ret.first = ParseOptRet::VersionRequested;
     return ret;
   }

--- a/src/MainOpt.cpp
+++ b/src/MainOpt.cpp
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #endif
 #include "SchemaRegistry.h"
+#include "Version.h"
 #include "git_commit_current.h"
 #include "helper.h"
 #include "logger.h"
@@ -129,13 +130,17 @@ CLI::Option *addKafkaOption(CLI::App &App, std::string const &Name,
   return SetKeyValueOptions(App, Name, Description, Defaulted, Fun);
 }
 
-std::pair<int, std::unique_ptr<MainOpt>> parse_opt(int argc, char **argv) {
-  std::pair<int, std::unique_ptr<MainOpt>> ret{0, make_unique<MainOpt>()};
+std::pair<ParseOptRet, std::unique_ptr<MainOpt>> parse_opt(int argc,
+                                                           char **argv) {
+  std::pair<ParseOptRet, std::unique_ptr<MainOpt>> ret{ParseOptRet::Success,
+                                                       make_unique<MainOpt>()};
   auto &MainOptions = *ret.second;
   CLI::App App{
       fmt::format("forward-epics-to-kafka-0.1.0 {:.7} (ESS, BrightnESS)\n"
                   "  https://github.com/ess-dmsc/forward-epics-to-kafka\n\n",
                   GIT_COMMIT)};
+  App.add_flag("--version", MainOptions.PrintVersion,
+               "Print application version and exit");
   App.add_option("--log-file", MainOptions.LogFilename, "Log filename");
   App.add_option("--streams-json", MainOptions.StreamsFile,
                  "Json file for streams to add")
@@ -192,17 +197,26 @@ std::pair<int, std::unique_ptr<MainOpt>> parse_opt(int argc, char **argv) {
   try {
     App.parse(argc, argv);
   } catch (CLI::CallForHelp const &) {
-    ret.first = 1;
+    ret.first = ParseOptRet::Error;
   } catch (CLI::ParseError const &e) {
-    spdlog::log(spdlog::level::err, "Can not parse command line options: {}",
-                e.what());
-    ret.first = 1;
+    if (!MainOptions.PrintVersion) {
+      spdlog::log(spdlog::level::err, "Can not parse command line options: {}",
+                  e.what());
+      ret.first = ParseOptRet::Error;
+    }
   }
+
+  if (MainOptions.PrintVersion) {
+    fmt::print("{}\n", GetVersion());
+    ret.first = ParseOptRet::VersionRequested;
+    return ret;
+  }
+
   setUpLogging(MainOptions.LogLevel, MainOptions.LogFilename,
                MainOptions.GraylogLoggerAddress);
   SharedLogger Logger = getLogger();
 
-  if (ret.first == 1) {
+  if (ret.first == ParseOptRet::Error) {
     std::cout << App.help();
     return ret;
   }
@@ -212,7 +226,7 @@ std::pair<int, std::unique_ptr<MainOpt>> parse_opt(int argc, char **argv) {
           parseStreamsJson(MainOptions.StreamsFile);
     } catch (std::exception const &e) {
       Logger->warn("Can not parse configuration file: {}", e.what());
-      ret.first = 1;
+      ret.first = ParseOptRet::Error;
       return ret;
     }
   }

--- a/src/MainOpt.h
+++ b/src/MainOpt.h
@@ -23,6 +23,7 @@ std::vector<StreamSettings> parseStreamsJson(const std::string &filepath);
 
 struct MainOpt {
   ConfigSettings MainSettings;
+  bool PrintVersion = false;
   std::string KafkaGELFAddress = "";
   spdlog::level::level_enum LogLevel;
   std::string GraylogLoggerAddress = "";
@@ -35,6 +36,9 @@ struct MainOpt {
   KafkaW::BrokerSettings GlobalBrokerSettings;
 };
 
-std::pair<int, std::unique_ptr<MainOpt>> parse_opt(int argc, char **argv);
+enum class ParseOptRet { Success, VersionRequested, Error };
+
+std::pair<ParseOptRet, std::unique_ptr<MainOpt>> parse_opt(int argc,
+                                                           char **argv);
 
 } // namespace Forwarder


### PR DESCRIPTION
### Issue

DM-1088

### Description of work

Add versioning support with CMake, as done for kafka-to-nexus and event-formation-unit. In this case, the `GetVersion` function had to be put in a separate namespace, as the name conflicted with what seemed to be a Windows function.

### Nominate for Group Code Review

- [ ] Nominate for code review 
