### PR TITLE
Remove unused field from PV Update class

### DIFF
--- a/src/EpicsClient/EpicsClientRandom.cpp
+++ b/src/EpicsClient/EpicsClientRandom.cpp
@@ -24,7 +24,6 @@ void EpicsClientRandom::generateFakePVUpdate() {
   FakePVUpdate->epics_pvstr = epics::pvData::PVStructure::shared_pointer(
       createFakePVStructure(UniformDistribution(RandomEngine)));
   FakePVUpdate->channel = ChannelInformation.channel_name;
-  FakePVUpdate->ts_epics_monitor = getCurrentTimestamp();
 
   emit(std::move(FakePVUpdate));
 }

--- a/src/EpicsClient/FwdMonitorRequester.cpp
+++ b/src/EpicsClient/FwdMonitorRequester.cpp
@@ -77,9 +77,6 @@ void FwdMonitorRequester::monitorEvent(
 
     static_assert(sizeof(uint64_t) == sizeof(std::chrono::nanoseconds::rep),
                   "Types not compatible");
-    int64_t ts = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                     std::chrono::system_clock::now().time_since_epoch())
-                     .count();
 
     // Seems like MonitorElement always returns a Structure type ?
     // The inheritance diagram shows that scalars derive from Field, not from
@@ -92,7 +89,6 @@ void FwdMonitorRequester::monitorEvent(
         new ::epics::pvData::PVStructure(ele->pvStructurePtr->getStructure()));
     Update->epics_pvstr->copyUnchecked(*ele->pvStructurePtr);
     Monitor->release(ele);
-    Update->ts_epics_monitor = ts;
     Updates.push_back(Update);
   }
   for (auto &up : Updates) {

--- a/src/EpicsPVUpdate.h
+++ b/src/EpicsPVUpdate.h
@@ -22,9 +22,6 @@ struct EpicsPVUpdate {
   EpicsPVUpdate(EpicsPVUpdate &&) = delete;
   ~EpicsPVUpdate() = default;
   ::epics::pvData::PVStructure::shared_pointer epics_pvstr;
-  /// Do not rely on channel, will likely go away...
   std::string channel;
-  /// Timestamp when monitorEvent() was called
-  uint64_t ts_epics_monitor = 0;
 };
 }


### PR DESCRIPTION
No ticket, just cleaning up something I noticed when working on another issue.

Removed `ts_epics_monitor` from `EpicsPVUpdate` as it was assigned but never accessed.

Also removed the unhelpful comment `/// Do not rely on channel, will likely go away...`
as the only person who may have some idea how it can "go away" doesn't work on this code base any more.