### PR TITLE
typo - changed file-writer to forwarder

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ verbosity=5
 Note: the Kafka options are key-value pairs and the forwarder can be given multiple by appending the key-value pair to 
 the end of the command line option.
 
-### Sending commands to the file-writer
+### Sending commands to the forwarder
 
 Beyond the configuration options given at start-up, the forwarder can be sent commands via Kafka to configure which PVs 
 are forwarded.


### PR DESCRIPTION
### Issue

None

### Description of work

The forwarder does not send commands to the filewriter, fixed a typo meaning to say "sending commands to the forwarder" 

### Nominate for Group Code Review

- [ ] Nominate for code review 
