### PR TITLE
Count report iterations occurring so can be polled in tests

### DIFF
--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -9,7 +9,7 @@ CLI11/1.8.0@cliutils/stable
 jsonformoderncpp/3.6.1@vthiery/stable
 concurrentqueue/8f7e861@ess-dmsc/stable
 asio/1.13.0@bincrafters/stable
-trompeloeil/v31@ess-dmsc/stable
+trompeloeil/v36@rollbear/stable
 
 [generators]
 cmake

--- a/conan/conanfile_win32.txt
+++ b/conan/conanfile_win32.txt
@@ -9,7 +9,7 @@ CLI11/1.8.0@cliutils/stable
 jsonformoderncpp/3.6.1@vthiery/stable
 concurrentqueue/8f7e861@ess-dmsc/stable
 asio/1.13.0@bincrafters/stable
-trompeloeil/v31@ess-dmsc/stable
+trompeloeil/v36@rollbear/stable
 
 [generators]
 cmake

--- a/conan/conanfile_win32_no_epics.txt
+++ b/conan/conanfile_win32_no_epics.txt
@@ -8,7 +8,7 @@ CLI11/1.8.0@cliutils/stable
 jsonformoderncpp/3.6.1@vthiery/stable
 concurrentqueue/8f7e861@ess-dmsc/stable
 asio/1.13.0@bincrafters/stable
-trompeloeil/v31@ess-dmsc/stable
+trompeloeil/v36@rollbear/stable
 
 [generators]
 cmake

--- a/src/MetricsReporter.cpp
+++ b/src/MetricsReporter.cpp
@@ -107,7 +107,6 @@ void MetricsReporter::reportMetrics() {
     }
     CURLReporter::send(StatsBuffer, MainOptions.InfluxURI);
   }
-  ReportIterations++;
 
   AsioTimer.expires_at(AsioTimer.expires_at() + Period);
   AsioTimer.async_wait([this](std::error_code const &Error) {

--- a/src/MetricsReporter.cpp
+++ b/src/MetricsReporter.cpp
@@ -107,6 +107,8 @@ void MetricsReporter::reportMetrics() {
     }
     CURLReporter::send(StatsBuffer, MainOptions.InfluxURI);
   }
+  ReportIterations++;
+
   AsioTimer.expires_at(AsioTimer.expires_at() + Period);
   AsioTimer.async_wait([this](std::error_code const &Error) {
     if (Error != asio::error::operation_aborted) {

--- a/src/MetricsReporter.h
+++ b/src/MetricsReporter.h
@@ -32,8 +32,11 @@ public:
   std::unique_lock<std::mutex> get_lock_converters();
 
   void reportMetrics();
-
   ~MetricsReporter();
+
+  // Used for testing, so that we can poll to see when report iterations have
+  // happened instead of relying on them happening within a short time frame
+  std::atomic_uint64_t ReportIterations{0};
 
 private:
   void run() { IO.run(); }

--- a/src/MetricsReporter.h
+++ b/src/MetricsReporter.h
@@ -34,10 +34,6 @@ public:
   void reportMetrics();
   ~MetricsReporter();
 
-  // Used for testing, so that we can poll to see when report iterations have
-  // happened instead of relying on them happening within a short time frame
-  std::atomic_uint64_t ReportIterations{0};
-
 private:
   void run() { IO.run(); }
   asio::io_context IO;

--- a/src/StatusReporter.cpp
+++ b/src/StatusReporter.cpp
@@ -50,8 +50,6 @@ void StatusReporter::reportStatus() {
   StatusProducerTopic->produce((unsigned char *)StatusString.c_str(),
                                StatusString.size());
 
-  ReportIterations++;
-
   AsioTimer.expires_at(AsioTimer.expires_at() + Period);
   AsioTimer.async_wait([this](std::error_code const &Error) {
     if (Error != asio::error::operation_aborted) {

--- a/src/StatusReporter.cpp
+++ b/src/StatusReporter.cpp
@@ -49,6 +49,9 @@ void StatusReporter::reportStatus() {
   }
   StatusProducerTopic->produce((unsigned char *)StatusString.c_str(),
                                StatusString.size());
+
+  ReportIterations++;
+
   AsioTimer.expires_at(AsioTimer.expires_at() + Period);
   AsioTimer.async_wait([this](std::error_code const &Error) {
     if (Error != asio::error::operation_aborted) {

--- a/src/StatusReporter.h
+++ b/src/StatusReporter.h
@@ -24,8 +24,11 @@ public:
       Streams &MainLoopStreams);
 
   void reportStatus();
-
   ~StatusReporter();
+
+  // Used for testing, so that we can poll to see when report iterations have
+  // happened instead of relying on them happening within a short time frame
+  std::atomic_uint64_t ReportIterations{0};
 
 private:
   void run() { IO.run(); }

--- a/src/StatusReporter.h
+++ b/src/StatusReporter.h
@@ -26,10 +26,6 @@ public:
   void reportStatus();
   ~StatusReporter();
 
-  // Used for testing, so that we can poll to see when report iterations have
-  // happened instead of relying on them happening within a short time frame
-  std::atomic_uint64_t ReportIterations{0};
-
 private:
   void run() { IO.run(); }
   asio::io_context IO;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -25,7 +25,9 @@ set(tests_SRC
     MetricsReporterTests.cpp
     MockKafkaInstanceSet.h
     StatusReporterTests.cpp
-    MockProducer.h)
+    MockProducer.h
+    ReporterHelpers.h
+    ReporterHelpers.cpp)
 
 find_package(Trompeloeil REQUIRED)
 add_executable(tests ${tests_SRC})

--- a/src/tests/MetricsReporterTests.cpp
+++ b/src/tests/MetricsReporterTests.cpp
@@ -9,6 +9,19 @@ using trompeloeil::_;
 class MetricsReporterTest : public ::testing::Test {};
 
 namespace Forwarder {
+
+void waitForReportIterations(MetricsReporter &Reporter,
+                             uint32_t const NumberOfIterationsToWaitFor) {
+  auto PollInterval = 50ms;
+  auto TotalWait = 0ms;
+  auto TimeOut = 10s; // Max wait time, prevent test hanging indefinitely
+  while (Reporter.ReportIterations < NumberOfIterationsToWaitFor &&
+         TotalWait < TimeOut) {
+    std::this_thread::sleep_for(PollInterval);
+    TotalWait += PollInterval;
+  }
+}
+
 TEST(MetricsReporterTest, MetricsReporterLogsKafkaMetrics) {
   auto Interval = 10ms;
   auto TestKafkaInstanceSet = std::shared_ptr<InstanceSet>(
@@ -18,9 +31,11 @@ TEST(MetricsReporterTest, MetricsReporterLogsKafkaMetrics) {
   MainOpt MainOptions;
   MetricsReporter TestMetricsTimer(Interval, MainOptions, TestKafkaInstanceSet);
 
-  REQUIRE_CALL(*KafkaInstanceSet, logMetrics()).TIMES(AT_LEAST(2));
+  uint32_t const ReportsToWaitFor = 2;
 
-  std::this_thread::sleep_for(100ms);
+  REQUIRE_CALL(*KafkaInstanceSet, logMetrics())
+      .TIMES(AT_LEAST(ReportsToWaitFor));
+
+  waitForReportIterations(TestMetricsTimer, ReportsToWaitFor);
 }
-
 } // namespace Forwarder

--- a/src/tests/ReporterHelpers.cpp
+++ b/src/tests/ReporterHelpers.cpp
@@ -1,0 +1,17 @@
+#include "ReporterHelpers.h"
+#include <chrono>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+void waitForReportIterations(uint32_t const NumberOfIterationsToWaitFor,
+                             std::atomic<uint32_t> &ReportIterations) {
+  auto PollInterval = 50ms;
+  auto TotalWait = 0ms;
+  auto TimeOut = 10s; // Max wait time, prevent test hanging indefinitely
+  while (ReportIterations < NumberOfIterationsToWaitFor &&
+         TotalWait < TimeOut) {
+    std::this_thread::sleep_for(PollInterval);
+    TotalWait += PollInterval;
+  }
+}

--- a/src/tests/ReporterHelpers.h
+++ b/src/tests/ReporterHelpers.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This code has been produced by the European Spallation Source
+// and its partner institutes under the BSD 2 Clause License.
+//
+// See LICENSE.md at the top level for license information.
+//
+// Screaming Udder!                              https://esss.se
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+void waitForReportIterations(uint32_t NumberOfIterationsToWaitFor,
+                             std::atomic<uint32_t> &ReportIterations);

--- a/src/tests/StatusReporterTests.cpp
+++ b/src/tests/StatusReporterTests.cpp
@@ -9,6 +9,19 @@ using trompeloeil::_;
 class StatusReporterTest : public ::testing::Test {};
 
 namespace Forwarder {
+
+void waitForReportIterations(StatusReporter &Reporter,
+                             uint32_t const NumberOfIterationsToWaitFor) {
+  auto PollInterval = 50ms;
+  auto TotalWait = 0ms;
+  auto TimeOut = 10s; // Max wait time, prevent test hanging indefinitely
+  while (Reporter.ReportIterations < NumberOfIterationsToWaitFor &&
+         TotalWait < TimeOut) {
+    std::this_thread::sleep_for(PollInterval);
+    TotalWait += PollInterval;
+  }
+}
+
 TEST(StatusReporterTest, StatusReporterCallsProduce) {
   auto Interval = 10ms;
   MainOpt MainOptions;
@@ -23,13 +36,16 @@ TEST(StatusReporterTest, StatusReporterCallsProduce) {
   ApplicationStatusProducerTopic =
       std::make_unique<KafkaW::ProducerTopic>(KafkaProducer, TopicName);
 
+  uint32_t const ReportsToWaitFor = 2;
+
   REQUIRE_CALL(*MockKafkaProducer, produce(_, _, _, _, _, _, _, _))
-      .TIMES(AT_LEAST(1))
+      .TIMES(AT_LEAST(ReportsToWaitFor))
       .RETURN(RdKafka::ErrorCode::ERR_NO_ERROR);
 
   StatusReporter TestStatusReporter(Interval, MainOptions,
                                     ApplicationStatusProducerTopic, streams);
-  std::this_thread::sleep_for(100ms);
+
+  waitForReportIterations(TestStatusReporter, ReportsToWaitFor);
 }
 
 } // namespace Forwarder

--- a/src/tests/StatusReporterTests.cpp
+++ b/src/tests/StatusReporterTests.cpp
@@ -1,5 +1,6 @@
 #include "MockProducer.h"
-#include <StatusReporter.h>
+#include "ReporterHelpers.h"
+#include "StatusReporter.h"
 #include <gtest/gtest.h>
 #include <trompeloeil.hpp>
 
@@ -9,18 +10,6 @@ using trompeloeil::_;
 class StatusReporterTest : public ::testing::Test {};
 
 namespace Forwarder {
-
-void waitForReportIterations(StatusReporter &Reporter,
-                             uint32_t const NumberOfIterationsToWaitFor) {
-  auto PollInterval = 50ms;
-  auto TotalWait = 0ms;
-  auto TimeOut = 10s; // Max wait time, prevent test hanging indefinitely
-  while (Reporter.ReportIterations < NumberOfIterationsToWaitFor &&
-         TotalWait < TimeOut) {
-    std::this_thread::sleep_for(PollInterval);
-    TotalWait += PollInterval;
-  }
-}
 
 TEST(StatusReporterTest, StatusReporterCallsProduce) {
   auto Interval = 10ms;
@@ -37,15 +26,18 @@ TEST(StatusReporterTest, StatusReporterCallsProduce) {
       std::make_unique<KafkaW::ProducerTopic>(KafkaProducer, TopicName);
 
   uint32_t const ReportsToWaitFor = 2;
+  std::atomic<uint32_t> ReportIterations{0};
 
   REQUIRE_CALL(*MockKafkaProducer, produce(_, _, _, _, _, _, _, _))
       .TIMES(AT_LEAST(ReportsToWaitFor))
-      .RETURN(RdKafka::ErrorCode::ERR_NO_ERROR);
+      .RETURN(RdKafka::ErrorCode::ERR_NO_ERROR)
+      .LR_SIDE_EFFECT(ReportIterations++);
+  ;
 
   StatusReporter TestStatusReporter(Interval, MainOptions,
                                     ApplicationStatusProducerTopic, streams);
 
-  waitForReportIterations(TestStatusReporter, ReportsToWaitFor);
+  waitForReportIterations(ReportsToWaitFor, ReportIterations);
 }
 
 } // namespace Forwarder


### PR DESCRIPTION
Proposed solution to possibility of tests in #313 failing.

Added a counter for report iterations. Unit tests poll this until the expected number of iterations, or a generous maximum timeout of 10 seconds, is reached.