### PR TITLE
Revert "EPICS cool down" to original value

### DIFF
--- a/src/Streams.cpp
+++ b/src/Streams.cpp
@@ -36,7 +36,7 @@ void Streams::clearStreams() {
       Stream->stop();
     }
     // Wait for Epics to cool down
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     StreamPointers.clear();
   }
   Logger->trace("Main::clearStreams()  end");


### PR DESCRIPTION
Mistakenly modified in PR #317, this just reverts the value.

Will investigate if it can be removed altogether: DM-1847