### PR TITLE
Use gold linker when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,16 @@ else()
     endif()
 endif(WIN32)
 
+# Use gold linker if available on system (it is faster than default GNU linker)
+if (UNIX AND NOT APPLE)
+  execute_process(COMMAND ${CMAKE_C_COMPILER} -fuse-ld=gold -Wl,--version ERROR_QUIET OUTPUT_VARIABLE ld_version)
+  if ("${ld_version}" MATCHES "GNU gold")
+    message(STATUS "Using gold linker")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold -Wl,--disable-new-dtags")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=gold -Wl,--disable-new-dtags")
+  endif()
+endif()
+
 # Test Coverage - with gcc only and enable with -DCOV
 if(CMAKE_COMPILER_IS_GNUCXX AND COV)
     include(CodeCoverage)


### PR DESCRIPTION
gold linker is a faster alternative to the default GNU linker on Linux.
These few lines of CMake allow us to make use of it when it is available on the system. It is already available on all of our Linux build containers.

Tested on the file writer code base:
On the machine I tested on (16 core, 4.5GHz, Ubuntu 19.10, gcc 9.2.1, ninja) it results in clean build time going from 1m7s to 58s (3 repetitions with each, all repetitions were within 300ms of each other). A reduction of ~15%. Reduction is a larger percentage for incremental builds, since linking is a larger proportion of the build time in that case.
