### PR TITLE
Fix crash by returning default values if no alarm field present.

### DIFF
--- a/src/EpicsClient/EpicsClientMonitor.cpp
+++ b/src/EpicsClient/EpicsClientMonitor.cpp
@@ -70,6 +70,9 @@ int EpicsClientMonitor::stop() { return Impl->stop(); }
 
 bool EpicsClientMonitor::alarmMessageChanged(
     std::shared_ptr<FlatBufs::EpicsPVUpdate> &Update) {
+  if (Update->epics_pvstr->getSubField("alarm") == nullptr) {
+    return false;
+  }
   auto CurrentAlarmString = getAlarmStringFromUpdate(Update);
   auto CachedAlarmString = getAlarmStringFromUpdate(CachedUpdate);
   return CurrentAlarmString != CachedAlarmString;

--- a/src/schemas/f142/DataFromPVStruct.cpp
+++ b/src/schemas/f142/DataFromPVStruct.cpp
@@ -15,6 +15,9 @@ std::map<epics::pvData::AlarmSeverity, AlarmSeverity>
 AlarmStatus
 getAlarmStatus(epics::pvData::PVStructurePtr const &PVStructureField) {
   auto AlarmField = PVStructureField->getSubField("alarm");
+  if (AlarmField == nullptr) {
+    return AlarmStatus::NO_ALARM;
+  }
   auto MessageField =
       (dynamic_cast<epics::pvData::PVStructure *>(AlarmField.get()))
           ->getSubField("message");
@@ -42,6 +45,9 @@ getAlarmStatus(epics::pvData::PVStructurePtr const &PVStructureField) {
 AlarmSeverity
 getAlarmSeverity(epics::pvData::PVStructurePtr const &PVStructureField) {
   auto AlarmField = PVStructureField->getSubField("alarm");
+  if (AlarmField == nullptr) {
+    return AlarmSeverity::NO_ALARM;
+  }
   auto SeverityField =
       (dynamic_cast<epics::pvData::PVStructure *>(AlarmField.get()))
           ->getSubField("severity");

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ set(tests_SRC
     ConsumerTests.cpp
     MockMessage.h
     ConvertTDCTest.cpp
-    f142DataFromPVStructTests.cpp
+    GetAlarmDetailsTests.cpp
     UnitTests.cpp
     MetricsReporterTests.cpp
     MockKafkaInstanceSet.h

--- a/src/tests/GetAlarmDetailsTests.cpp
+++ b/src/tests/GetAlarmDetailsTests.cpp
@@ -4,12 +4,8 @@
 #include <pv/pvAlarm.h>
 #include <pv/pvTimeStamp.h>
 
-epics::pvData::PVStructure::shared_pointer
-CreateTestPVStructWithAlarm(std::string const &AlarmMessage,
-                            epics::pvData::AlarmSeverity AlarmSeverityLevel =
-                                epics::pvData::AlarmSeverity::noAlarm) {
-  auto Builder = epics::nt::NTScalar::createBuilder();
-  Builder->addAlarm();
+epics::nt::NTScalarPtr
+createPVStructure(epics::nt::NTScalarBuilderPtr const &Builder) {
   auto PVStruct =
       Builder->value(epics::pvData::pvDouble)->addTimeStamp()->create();
   auto ValueField = PVStruct->getValue<epics::pvData::PVDouble>();
@@ -18,6 +14,16 @@ CreateTestPVStructWithAlarm(std::string const &AlarmMessage,
   TS.getCurrent();
   epics::pvData::PVTimeStamp pvTS;
   PVStruct->attachTimeStamp(pvTS);
+  return PVStruct;
+}
+
+epics::pvData::PVStructure::shared_pointer
+createTestPVStructWithAlarm(std::string const &AlarmMessage,
+                            epics::pvData::AlarmSeverity AlarmSeverityLevel =
+                                epics::pvData::AlarmSeverity::noAlarm) {
+  auto Builder = epics::nt::NTScalar::createBuilder();
+  Builder->addAlarm();
+  auto PVStruct = createPVStructure(Builder);
 
   // Construct an alarm structure
   auto AlarmData = epics::pvData::Alarm();
@@ -31,15 +37,21 @@ CreateTestPVStructWithAlarm(std::string const &AlarmMessage,
   return PVStruct->getPVStructure();
 }
 
+epics::pvData::PVStructure::shared_pointer createTestPVStructWithoutAlarm() {
+  auto Builder = epics::nt::NTScalar::createBuilder();
+  auto PVStruct = createPVStructure(Builder);
+  return PVStruct->getPVStructure();
+}
+
 void testAlarmStatusFromAlarmMessage(std::string const &AlarmMessage,
                                      AlarmStatus ExpectedAlarmStatus) {
-  auto PVStruct = CreateTestPVStructWithAlarm(AlarmMessage);
+  auto PVStruct = createTestPVStructWithAlarm(AlarmMessage);
   auto AlarmStatusFromStruct = FlatBufs::f142::getAlarmStatus(PVStruct);
   ASSERT_EQ(AlarmStatusFromStruct, ExpectedAlarmStatus);
 }
 
 TEST(
-    f142Test,
+    GetAlarmDetailsTest,
     test_getAlarmStatus_returns_expected_status_based_on_alarm_message_in_pv_structure) {
   testAlarmStatusFromAlarmMessage("NO_ALARM", AlarmStatus::NO_ALARM);
   testAlarmStatusFromAlarmMessage("HIHI_ALARM", AlarmStatus::HIHI);
@@ -48,17 +60,24 @@ TEST(
                                   AlarmStatus::READ_ACCESS);
 }
 
+TEST(GetAlarmDetailsTest,
+     test_getAlarmStatus_returns_no_alarm_if_no_alarm_struct_in_pv) {
+  auto PVStruct = createTestPVStructWithoutAlarm();
+  auto AlarmStatusFromStruct = FlatBufs::f142::getAlarmStatus(PVStruct);
+  ASSERT_EQ(AlarmStatusFromStruct, AlarmStatus::NO_ALARM);
+}
+
 void testAlarmSeverityFromAlarmStruct(
     epics::pvData::AlarmSeverity AlarmSeverityInStruct,
     AlarmSeverity ExpectedAlarmSeverity) {
   auto PVStruct =
-      CreateTestPVStructWithAlarm("NO_ALARM", AlarmSeverityInStruct);
-  auto AlarmStatusFromStruct = FlatBufs::f142::getAlarmSeverity(PVStruct);
-  ASSERT_EQ(AlarmStatusFromStruct, ExpectedAlarmSeverity);
+      createTestPVStructWithAlarm("NO_ALARM", AlarmSeverityInStruct);
+  auto AlarmSeverityFromStruct = FlatBufs::f142::getAlarmSeverity(PVStruct);
+  ASSERT_EQ(AlarmSeverityFromStruct, ExpectedAlarmSeverity);
 }
 
 TEST(
-    f142Test,
+    GetAlarmDetailsTest,
     test_getAlarmSeverity_returns_expected_severity_based_on_alarm_in_pv_structure) {
   testAlarmSeverityFromAlarmStruct(epics::pvData::AlarmSeverity::noAlarm,
                                    AlarmSeverity::NO_ALARM);
@@ -70,4 +89,11 @@ TEST(
                                    AlarmSeverity::INVALID);
   testAlarmSeverityFromAlarmStruct(epics::pvData::AlarmSeverity::undefinedAlarm,
                                    AlarmSeverity::INVALID);
+}
+
+TEST(GetAlarmDetailsTest,
+     test_getAlarmSeverity_returns_no_alarm_if_no_alarm_struct_in_pv) {
+  auto PVStruct = createTestPVStructWithoutAlarm();
+  auto AlarmSeverityFromStruct = FlatBufs::f142::getAlarmSeverity(PVStruct);
+  ASSERT_EQ(AlarmSeverityFromStruct, AlarmSeverity::NO_ALARM);
 }


### PR DESCRIPTION
### Issue

*DM-1855

### Note

I could see no unit tests for explicitly testing this part of the code base so I did not care to write my own either.